### PR TITLE
Add `pexrc repackage` for re-compressing whls.

### DIFF
--- a/crates/pex/src/lib.rs
+++ b/crates/pex/src/lib.rs
@@ -22,4 +22,12 @@ pub use pex::{
 };
 pub use pex_info::{BinPath, InheritPath, InterpreterSelectionStrategy, PexInfo};
 pub use pex_path::PexPath;
-pub use wheel::{EntryPoint, EntryPoints, WheelMetadata, WheelOptions, repackage_wheels};
+pub use wheel::{
+    EntryPoint,
+    EntryPoints,
+    WheelFile,
+    WheelMetadata,
+    WheelOptions,
+    recompress_zipped_whl,
+    repackage_wheels,
+};

--- a/crates/pex/src/wheel/file.rs
+++ b/crates/pex/src/wheel/file.rs
@@ -65,7 +65,7 @@ pub struct WheelFile<'a> {
 }
 
 impl<'a> WheelFile<'a> {
-    pub(crate) fn parse_file_name(file_name: &'a str) -> anyhow::Result<Self> {
+    pub fn parse_file_name(file_name: &'a str) -> anyhow::Result<Self> {
         // See: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention
         // {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
         if !file_name.ends_with(".whl") {
@@ -132,15 +132,15 @@ impl<'a> WheelFile<'a> {
         })
     }
 
-    pub fn data_dir(&self) -> WheelDir<'a> {
+    pub(crate) fn data_dir(&self) -> WheelDir<'a> {
         self.wheel_dir("data")
     }
 
-    pub fn dist_info_dir(&self) -> WheelDir<'a> {
+    pub(crate) fn dist_info_dir(&self) -> WheelDir<'a> {
         self.wheel_dir("dist-info")
     }
 
-    pub fn pex_info_dir(&self) -> WheelDir<'a> {
+    pub(crate) fn pex_info_dir(&self) -> WheelDir<'a> {
         self.wheel_dir("pex-info")
     }
 

--- a/crates/pex/src/wheel/mod.rs
+++ b/crates/pex/src/wheel/mod.rs
@@ -10,7 +10,7 @@ mod package;
 mod record;
 
 pub use entry_points::{EntryPoint, EntryPoints};
-pub(crate) use file::WheelFile;
+pub use file::WheelFile;
 pub(crate) use metadata::MetadataReader;
 pub use metadata::WheelMetadata;
-pub use package::{WheelOptions, repackage_wheels};
+pub use package::{WheelOptions, recompress_zipped_whl, repackage_wheels};

--- a/crates/pex/src/wheel/package.rs
+++ b/crates/pex/src/wheel/package.rs
@@ -172,7 +172,7 @@ fn repackage_directory_pex_wheel(
     }
 }
 
-fn recompress_zipped_whl(
+pub fn recompress_zipped_whl(
     mut wheel: ZipArchive<impl Read + Seek>,
     wheel_file: &WheelFile,
     options: &WheelOptions,

--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -259,7 +259,12 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
         .unwrap_or_else(|| {
             format!(
                 "({venv_name})",
-                venv_name = args.venv_dir.file_name().expect("XXX").display()
+                venv_name = args
+                    .venv_dir
+                    .file_name()
+                    .or_else(|| pex.path.file_name())
+                    .unwrap_or_else(|| OsStr::new("venv"))
+                    .display()
             )
         });
     let venv_dir = args

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use pex::{Pex, WheelOptions};
-use pexrc::commands::{extract, info, inject, script};
+use pexrc::commands::{extract, info, inject, repackage, script};
 use pexrc::embeds::{CLIB_BY_TARGET, PROXY_BY_TARGET};
 use pexrc::source;
 use target::Target;
@@ -78,6 +78,21 @@ enum Commands {
     },
     /// Provide information about the supported target runtimes.
     Info,
+    /// Re-package a traditional whl as a zstd compressed whl.
+    Repackage {
+        #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
+        compression_method: CompressionMethod,
+
+        #[arg(long)]
+        compression_level: Option<i64>,
+
+        /// The directory to extract the wheels to.
+        #[arg(short = 'd', long)]
+        dest_dir: PathBuf,
+
+        #[arg(value_name = "WHEEL", required = true)]
+        wheels: Vec<String>,
+    },
     /// Create a Windows-style Python venv console script executable.
     Script {
         #[arg(long)]
@@ -160,6 +175,22 @@ fn main() -> anyhow::Result<()> {
             )
         }
         Commands::Info => info::display(),
+        Commands::Repackage {
+            compression_method,
+            compression_level,
+            dest_dir,
+            wheels,
+        } => {
+            let wheels = wheels
+                .into_iter()
+                .map(|source| source::to_path(source, None))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            repackage::repackage_all(
+                wheels,
+                &WheelOptions::new(compression_method.into(), compression_level, None),
+                &dest_dir,
+            )
+        }
         Commands::Script {
             target,
             python,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,4 +4,5 @@
 pub mod extract;
 pub mod info;
 pub mod inject;
+pub mod repackage;
 pub mod script;

--- a/src/commands/repackage.rs
+++ b/src/commands/repackage.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use fs_err::File;
+use pex::{WheelFile, WheelOptions, recompress_zipped_whl};
+use zip::ZipArchive;
+
+pub fn repackage_all(
+    wheels: Vec<PathBuf>,
+    options: &WheelOptions,
+    dest_dir: &Path,
+) -> anyhow::Result<()> {
+    for wheel in wheels {
+        repackage(&wheel, options, dest_dir)?;
+    }
+    Ok(())
+}
+
+fn repackage(wheel: &Path, options: &WheelOptions, dest_dir: &Path) -> anyhow::Result<()> {
+    let wheel_file_name = wheel
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .ok_or_else(|| {
+            anyhow!(
+                "Wheel does not have a (UTF-8) filename!: {wheel}",
+                wheel = wheel.display()
+            )
+        })?;
+    let wheel_file = WheelFile::parse_file_name(wheel_file_name)?;
+    let zipped_whl = ZipArchive::new(File::open(wheel)?)?;
+    recompress_zipped_whl(zipped_whl, &wheel_file, options, dest_dir)?;
+    Ok(())
+}


### PR DESCRIPTION
The functionality was all there and this supported a side-experiment to
assess embedding pip 20.3.4, setuptools 44.1.1 and wheel 0.37.1 for
legacy virtualenv support in the venv PEX_TOOL.