### PR TITLE
Proper support for .data/ dirs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.8.0
+
+This release adds support for "un-spreading" legacy PEX wheel chroots when injecting a PEXrc and
+also for proper spreading of injected wheels at runtime. This covers all content delivered via
+wheel .data/ dirs that was previously not handled by `pexrc`.
+
 ## 0.7.1
 
 This release fixes injected `--sh-boot` PEXes to honor `PEX_TOOLS=1` and be robust to underlying

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,11 +1974,14 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "logging_timer",
+ "mailparse",
  "ouroboros",
  "pep440_rs",
  "pep508_rs",
  "python-pkginfo",
  "rayon",
+ "regex",
+ "rfc2047-decoder",
  "rstest",
  "rust-ini",
  "scripts",
@@ -1995,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 publish = false
 
@@ -168,6 +168,7 @@ is_executable = "1.0"
 itertools = "0.14"
 log = "0.4"
 logging_timer = "1.1"
+mailparse = "0.16"
 nix = {  version = "0.31", features = ["fs"] }
 oneshot = {  version = "0.2", features = ["std"] }
 open = "5.3"
@@ -179,6 +180,7 @@ pep508_rs = "0.9"
 python-pkginfo = "0.6"
 rayon = "1.12"
 regex = "1.12"
+rfc2047-decoder = "1.1"
 rstest = "0.26"
 rust-ini = "0.21"
 same-file = "1.0"

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -74,6 +75,7 @@ pub struct Interpreter {
     pub supported_tags: Vec<String>,
     pub has_ensurepip: bool,
     pub free_threaded: Option<bool>,
+    pub paths: BTreeMap<String, PathBuf>,
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/pex/Cargo.toml
+++ b/crates/pex/Cargo.toml
@@ -17,11 +17,14 @@ interpreter = { path = "../interpreter" }
 itertools = { workspace = true }
 log = { workspace = true }
 logging_timer = { workspace = true }
+mailparse = { workspace = true }
 ouroboros = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 python-pkginfo = { workspace = true }
 rayon = { workspace = true }
+regex = { workspace = true }
+rfc2047-decoder = { workspace = true }
 rust-ini = { workspace = true }
 scripts = { path = "../scripts" }
 serde = { workspace = true }

--- a/crates/pex/src/lib.rs
+++ b/crates/pex/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(clippy::all)]
+#![feature(str_as_str)]
 
 mod pex;
 mod pex_info;
@@ -10,6 +11,7 @@ mod wheel;
 
 pub use pex::{
     CollectWheelMetadata,
+    DataDir,
     Layout,
     Pex,
     Resolve,

--- a/crates/pex/src/pex.rs
+++ b/crates/pex/src/pex.rs
@@ -126,28 +126,36 @@ pub struct ResolvedWheel<'a> {
     file_name: &'a str,
     pub project_name: &'a str,
     pub version: &'a str,
+    pub root_is_purelib: bool,
+}
+
+pub struct DataDir(String);
+
+impl DataDir {
+    pub fn as_path(&self) -> &Path {
+        Path::new(&self.0)
+    }
 }
 
 impl<'a> ResolvedWheel<'a> {
-    pub fn data_dir(&self) -> PathBuf {
-        self.pnav_dir("data")
+    pub fn data_dir(&self) -> DataDir {
+        DataDir(self.pnav_dir("data"))
     }
 
     pub fn dist_info_dir(&self) -> PathBuf {
-        self.pnav_dir("dist-info")
+        self.pnav_dir("dist-info").into()
     }
 
     pub fn pex_info_info_dir(&self) -> PathBuf {
-        self.pnav_dir("pex-info")
+        self.pnav_dir("pex-info").into()
     }
 
-    fn pnav_dir(&self, name: &str) -> PathBuf {
+    fn pnav_dir(&self, name: &str) -> String {
         format!(
             "{project_name}-{version}.{name}",
             project_name = self.project_name,
             version = self.version
         )
-        .into()
     }
 }
 
@@ -274,6 +282,7 @@ impl<'a> Pex<'a> {
             version: Version,
             requires_dists: Vec<Requirement<Url>>,
             requires_python: Option<VersionSpecifiers>,
+            root_is_purelib: bool,
             rank: usize,
         }
 
@@ -290,6 +299,7 @@ impl<'a> Pex<'a> {
                     version: ranked_wheel.metadata.version,
                     requires_dists: ranked_wheel.metadata.requires_dists,
                     requires_python: ranked_wheel.metadata.requires_python,
+                    root_is_purelib: ranked_wheel.metadata.root_is_purelib,
                     rank: ranked_wheel.rank,
                 })
         }
@@ -363,6 +373,7 @@ impl<'a> Pex<'a> {
                 version,
                 requires_dists,
                 requires_python,
+                root_is_purelib,
                 ..
             } in wheels
             {
@@ -396,6 +407,7 @@ impl<'a> Pex<'a> {
                         version,
                         requires_dists: requires_dists.clone(),
                         requires_python,
+                        root_is_purelib,
                     })
                 }
                 resolved_by_project_name.insert(
@@ -404,6 +416,7 @@ impl<'a> Pex<'a> {
                         file_name,
                         project_name: raw_project_name,
                         version: raw_version,
+                        root_is_purelib,
                     },
                 );
                 for req in requires_dists {

--- a/crates/pex/src/wheel/metadata.rs
+++ b/crates/pex/src/wheel/metadata.rs
@@ -3,6 +3,8 @@
 
 use std::str::FromStr;
 
+use anyhow::anyhow;
+use mailparse::MailHeaderMap;
 use pep440_rs::{Version, VersionSpecifiers};
 use pep508_rs::{PackageName, Requirement};
 use python_pkginfo::Metadata;
@@ -18,6 +20,7 @@ pub struct WheelMetadata<'a> {
     pub version: Version,
     pub requires_dists: Vec<Requirement<Url>>,
     pub requires_python: Option<VersionSpecifiers>,
+    pub root_is_purelib: bool,
 }
 
 pub(crate) trait MetadataReader<'a> {
@@ -26,6 +29,18 @@ pub(crate) trait MetadataReader<'a> {
         wheel_file_name: &'a str,
         path_components: &[&str],
     ) -> anyhow::Result<String>;
+}
+
+fn parse_root_is_purelib_from_wheel(content: &[u8]) -> anyhow::Result<bool> {
+    let msg = mailparse::parse_mail(content)?;
+    let headers = msg.get_headers();
+    let header = headers
+        .get_first_header("Root-Is-Purelib")
+        .ok_or_else(|| anyhow!(""))?;
+    Ok(matches!(
+        rfc2047_decoder::decode(header.get_value_raw())?.as_str(),
+        "true" | "True"
+    ))
 }
 
 impl<'a> WheelMetadata<'a> {
@@ -55,6 +70,13 @@ impl<'a> WheelMetadata<'a> {
             None
         };
 
+        let components = [&dist_info_dir, "WHEEL"];
+        let root_is_purelib = parse_root_is_purelib_from_wheel(
+            metadata_reader
+                .read(wheel_file.file_name, &components)?
+                .as_bytes(),
+        )?;
+
         Ok(Self {
             file_name: wheel_file.file_name,
             raw_project_name: wheel_file.raw_project_name,
@@ -63,6 +85,7 @@ impl<'a> WheelMetadata<'a> {
             version: wheel_file.version,
             requires_dists,
             requires_python,
+            root_is_purelib,
         })
     }
 }

--- a/crates/pex/src/wheel/original_wheel_info.rs
+++ b/crates/pex/src/wheel/original_wheel_info.rs
@@ -1,9 +1,13 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
+use std::fmt::Display;
 use std::io::Read;
-use std::path::Path;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
 
+use anyhow::anyhow;
 use chrono::Utc;
 use fs_err::File;
 use ouroboros::self_referencing;
@@ -24,8 +28,45 @@ impl DateTime {
 }
 
 #[derive(Deserialize)]
+pub(crate) struct ZipFileName<'a>(Cow<'a, str>);
+
+impl<'a> ZipFileName<'a> {
+    pub(crate) fn from(path: PathBuf) -> anyhow::Result<Self> {
+        Ok(Self(Cow::Owned(
+            path.into_os_string()
+                .into_string()
+                .map_err(|err| anyhow!("Path is not UTF-8: {err}", err = err.display()))?,
+        )))
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn as_path(&self) -> Cow<'_, Path> {
+        Cow::Borrowed(Path::new(self.0.as_ref()))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn as_path(&self) -> Cow<'_, Path> {
+        Cow::Owned(self.0.split("/").collect())
+    }
+}
+
+impl<'a> Deref for ZipFileName<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &<Self as Deref>::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> Display for ZipFileName<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.write_str(self.0.as_ref())
+    }
+}
+
+#[derive(Deserialize)]
 struct RawOriginalWheelInfo<'a> {
-    entries: Vec<(&'a str, DateTime, u32)>,
+    entries: Vec<(ZipFileName<'a>, DateTime, u32)>,
     filename: &'a str,
 }
 
@@ -69,7 +110,7 @@ impl OriginalWheelInfo {
         &self,
         base_options: SimpleFileOptions,
         timestamp: Option<chrono::DateTime<Utc>>,
-    ) -> anyhow::Result<Vec<(&str, FileOptions<'static, ()>)>> {
+    ) -> anyhow::Result<Vec<(&ZipFileName<'_>, FileOptions<'static, ()>)>> {
         self.borrow_info()
             .entries
             .iter()
@@ -80,7 +121,7 @@ impl OriginalWheelInfo {
                     last_modified.as_zip_date_time()?
                 };
                 Ok((
-                    *name,
+                    name,
                     base_options
                         .last_modified_time(mtime)
                         .unix_permissions(external_attr >> 16),

--- a/crates/pex/src/wheel/package.rs
+++ b/crates/pex/src/wheel/package.rs
@@ -5,7 +5,8 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::io;
 use std::io::{Cursor, Read, Seek, Write};
-use std::path::{Component, Path};
+use std::ops::{Deref, DerefMut};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::bail;
@@ -14,6 +15,7 @@ use fs_err as fs;
 use fs_err::File;
 use logging_timer::time;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use walkdir::WalkDir;
 use zip::read::ZipArchiveMetadata;
 use zip::result::ZipError;
 use zip::write::SimpleFileOptions;
@@ -21,7 +23,7 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 use crate::wheel::WheelFile;
 use crate::wheel::layout::WheelLayout;
-use crate::wheel::original_wheel_info::OriginalWheelInfo;
+use crate::wheel::original_wheel_info::{OriginalWheelInfo, ZipFileName};
 use crate::wheel::record::Record;
 use crate::{Layout, Pex};
 
@@ -288,26 +290,45 @@ fn recompress_zipped_whl_chroot(
     };
 
     let data_dir = wheel_file.data_dir().as_path();
+    let mut zip_finder = ZipPathFinder {
+        zip: zipped_wheel_chroot,
+        prefix: if prefixed {
+            Some(prefix.to_string())
+        } else {
+            None
+        },
+    };
     let (dest_wheel, compressed_whl) = if let Some(wheel_info) = wheel_info {
         let dest_wheel = dest_dir.join(wheel_info.filename());
         let mut compressed_whl = ZipWriter::new(File::create(&dest_wheel)?);
-        for (dst_rel_path, options) in
+        for (zip_file_name, options) in
             wheel_info.iter_file_options(file_options, options.timestamp)?
         {
-            if dst_rel_path.ends_with(".pyc") {
+            if zip_file_name.ends_with(".pyc") {
                 continue;
             }
             let name = 'result: {
-                if let Ok(data_dir_rel_path) = Path::new(dst_rel_path).strip_prefix(&data_dir) {
+                if let Ok(data_dir_rel_path) = zip_file_name.as_path().strip_prefix(&data_dir) {
                     if let Some(stash_dir) = stash_dir.as_deref() {
                         break 'result format!(
                             "{prefix}{stash_dir}/{rel_path}",
                             stash_dir = stash_dir.display(),
-                            rel_path = normalized_data_dir_relpath(data_dir_rel_path).display()
+                            rel_path = normalized_data_dir_relpath(
+                                stash_dir,
+                                data_dir_rel_path,
+                                wheel_file,
+                                &zip_finder
+                            )?
+                            .display()
                         );
                     }
                     if legacy_bin_dir {
-                        let rel_path = normalized_data_dir_relpath(data_dir_rel_path);
+                        let rel_path = normalized_data_dir_relpath(
+                            Path::new("bin"),
+                            data_dir_rel_path,
+                            wheel_file,
+                            &zip_finder,
+                        )?;
                         assert!(starts_with(rel_path.as_ref(), "bin"));
                         break 'result format!(
                             "{prefix}{rel_path}",
@@ -315,25 +336,25 @@ fn recompress_zipped_whl_chroot(
                         );
                     }
                 }
-                format!("{prefix}{dst_rel_path}",)
+                format!("{prefix}{zip_file_name}")
             };
-            let mut src = match zipped_wheel_chroot.by_name(&name) {
+            let mut src = match zip_finder.by_name(&name) {
                 Ok(src) => src,
-                Err(_) if dst_rel_path.ends_with("/") => {
+                Err(_) if zip_file_name.ends_with("/") => {
                     // N.B.: Pex can omit original directory entries when those directories are
                     // empty.
-                    compressed_whl.add_directory(dst_rel_path, options)?;
+                    compressed_whl.add_directory(zip_file_name.to_string(), options)?;
                     continue;
                 }
                 Err(err) => bail!(
-                    "Mapped {dst_rel_path} in {file_name} to {name} which was not found: {err}",
+                    "Mapped {zip_file_name} in {file_name} to {name} which was not found: {err}",
                     file_name = wheel_file.file_name
                 ),
             };
             if src.is_dir() {
-                compressed_whl.add_directory_from_path(dst_rel_path, options)?;
+                compressed_whl.add_directory(zip_file_name.to_string(), options)?;
             } else {
-                compressed_whl.start_file_from_path(dst_rel_path, options)?;
+                compressed_whl.start_file(zip_file_name, options)?;
                 if src.name() == record_name {
                     compressed_whl.write_all(
                         record
@@ -359,30 +380,38 @@ fn recompress_zipped_whl_chroot(
         let mut compressed_whl = ZipWriter::new(File::create(&dest_wheel)?);
         for entry in record.entries() {
             let dst_rel_path = entry.path.as_ref();
-            let mut src = 'result: {
+            let name = 'result: {
                 if let Ok(data_dir_rel_path) = dst_rel_path.strip_prefix(&data_dir) {
                     if let Some(stash_dir) = stash_dir.as_deref() {
-                        break 'result zipped_wheel_chroot.by_name(&format!(
+                        break 'result format!(
                             "{prefix}{stash_dir}/{rel_path}",
                             stash_dir = stash_dir.display(),
-                            rel_path = normalized_data_dir_relpath(data_dir_rel_path).display()
-                        ))?;
+                            rel_path = normalized_data_dir_relpath(
+                                stash_dir,
+                                data_dir_rel_path,
+                                wheel_file,
+                                &zip_finder
+                            )?
+                            .display()
+                        );
                     }
                     if legacy_bin_dir {
-                        let rel_path = normalized_data_dir_relpath(data_dir_rel_path);
+                        let rel_path = normalized_data_dir_relpath(
+                            Path::new("bin"),
+                            data_dir_rel_path,
+                            wheel_file,
+                            &zip_finder,
+                        )?;
                         assert!(starts_with(rel_path.as_ref(), "bin"));
-                        break 'result zipped_wheel_chroot.by_name(&format!(
+                        break 'result format!(
                             "{prefix}{rel_path}",
                             rel_path = rel_path.as_ref().display()
-                        ))?;
+                        );
                     }
                 }
-                zipped_wheel_chroot.by_name(&format!(
-                    "{prefix}{rel_path}",
-                    rel_path = dst_rel_path.display()
-                ))?
+                format!("{prefix}{rel_path}", rel_path = dst_rel_path.display())
             };
-
+            let mut src = zip_finder.by_name(&name)?;
             compressed_whl.start_file_from_path(dst_rel_path, file_options)?;
             io::copy(&mut src, &mut compressed_whl)?;
         }
@@ -425,19 +454,30 @@ fn compress_whl_chroot(
     {
         let dest_wheel = dest_dir.join(wheel_info.filename());
         let mut compressed_whl = ZipWriter::new(File::create(&dest_wheel)?);
-        for (dst_rel_path, options) in
+        for (zip_file_name, options) in
             wheel_info.iter_file_options(file_options, options.timestamp)?
         {
-            if dst_rel_path.ends_with(".pyc") {
+            if zip_file_name.ends_with(".pyc") {
                 continue;
             }
-            let dst_rel_path = Path::new(dst_rel_path);
+            let dst_rel_path = zip_file_name.as_path();
+            let dst_rel_path = dst_rel_path.as_ref();
             let mut src = wheel_dir.join(dst_rel_path);
             if let Ok(data_dir_rel_path) = dst_rel_path.strip_prefix(&data_dir) {
                 if let Some(stash_dir) = stash_dir.as_deref() {
-                    src = stash_dir.join(normalized_data_dir_relpath(data_dir_rel_path))
+                    src = stash_dir.join(normalized_data_dir_relpath(
+                        stash_dir,
+                        data_dir_rel_path,
+                        wheel_file,
+                        &LoosePathFinder,
+                    )?)
                 } else if let Some(bin_dir) = legacy_bin_dir.as_deref() {
-                    let rel_path = normalized_data_dir_relpath(data_dir_rel_path);
+                    let rel_path = normalized_data_dir_relpath(
+                        bin_dir,
+                        data_dir_rel_path,
+                        wheel_file,
+                        &LoosePathFinder,
+                    )?;
                     assert!(starts_with(rel_path.as_ref(), "bin"));
                     src = bin_dir.join(rel_path)
                 }
@@ -477,9 +517,19 @@ fn compress_whl_chroot(
             let mut src = wheel_dir.join(dst_rel_path);
             if let Ok(data_dir_rel_path) = dst_rel_path.strip_prefix(&data_dir) {
                 if let Some(stash_dir) = stash_dir.as_deref() {
-                    src = stash_dir.join(normalized_data_dir_relpath(data_dir_rel_path))
+                    src = stash_dir.join(normalized_data_dir_relpath(
+                        stash_dir,
+                        data_dir_rel_path,
+                        wheel_file,
+                        &LoosePathFinder,
+                    )?)
                 } else if let Some(bin_dir) = legacy_bin_dir.as_deref() {
-                    let rel_path = normalized_data_dir_relpath(data_dir_rel_path);
+                    let rel_path = normalized_data_dir_relpath(
+                        bin_dir,
+                        data_dir_rel_path,
+                        wheel_file,
+                        &LoosePathFinder,
+                    )?;
                     assert!(starts_with(rel_path.as_ref(), "bin"));
                     src = bin_dir.join(rel_path)
                 }
@@ -498,18 +548,152 @@ fn starts_with(path: &Path, name: impl AsRef<OsStr>) -> bool {
     matches!(path.components().next(), Some(Component::Normal(named)) if named == name.as_ref())
 }
 
-fn normalized_data_dir_relpath(path: &Path) -> Cow<'_, Path> {
+trait ProjectPathFinder<'a> {
+    fn find(
+        &'a self,
+        strip_prefix: &Path,
+        prefix: PathBuf,
+        project: &WheelFile,
+        suffix: PathBuf,
+    ) -> anyhow::Result<Cow<'a, Path>>;
+}
+
+struct LoosePathFinder;
+
+impl<'a> ProjectPathFinder<'a> for LoosePathFinder {
+    fn find(
+        &'a self,
+        strip_prefix: &Path,
+        prefix: PathBuf,
+        project: &WheelFile,
+        suffix: PathBuf,
+    ) -> anyhow::Result<Cow<'a, Path>> {
+        for entry in WalkDir::new(strip_prefix.join(&prefix)).min_depth(1) {
+            let entry = entry?;
+            let prefix_rel_path = entry
+                .path()
+                .strip_prefix(strip_prefix)
+                .expect("We walked the prefix; so we can always safely strip it.");
+            if prefix_rel_path.ends_with(&suffix) {
+                for component in prefix_rel_path.components() {
+                    if let Some(name) = component.as_os_str().to_str()
+                        && (name == project.raw_project_name
+                            || name == project.project_name.as_ref())
+                    {
+                        return Ok(Cow::Owned(prefix_rel_path.to_owned()));
+                    }
+                }
+            }
+        }
+        bail!(
+            "Failed to find path in wheel {wheel} rooted at {root} with prefix {prefix} and \
+            suffix {suffix}",
+            wheel = project.file_name,
+            root = strip_prefix.display(),
+            prefix = prefix.display(),
+            suffix = suffix.display()
+        )
+    }
+}
+
+struct ZipPathFinder<R: Read + Seek> {
+    zip: ZipArchive<R>,
+    prefix: Option<String>,
+}
+
+impl<R: Read + Seek> Deref for ZipPathFinder<R> {
+    type Target = ZipArchive<R>;
+
+    fn deref(&self) -> &<Self as Deref>::Target {
+        &self.zip
+    }
+}
+
+impl<R: Read + Seek> DerefMut for ZipPathFinder<R> {
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
+        &mut self.zip
+    }
+}
+
+impl<'a, R: Read + Seek> ProjectPathFinder<'a> for ZipPathFinder<R> {
+    fn find(
+        &'a self,
+        strip_prefix: &Path,
+        prefix: PathBuf,
+        project: &WheelFile,
+        suffix: PathBuf,
+    ) -> anyhow::Result<Cow<'a, Path>> {
+        let (strip_prefix, prefix) = if let Some(zip_prefix) = self.prefix.as_deref() {
+            let strip_prefix = Path::new(zip_prefix).join(strip_prefix);
+            let zip_file_name_path = strip_prefix.join(prefix);
+            (
+                Cow::Owned(strip_prefix),
+                ZipFileName::from(zip_file_name_path)?,
+            )
+        } else {
+            (
+                Cow::Borrowed(strip_prefix),
+                ZipFileName::from(strip_prefix.join(prefix))?,
+            )
+        };
+        let suffix = ZipFileName::from(suffix)?;
+        for file_name in self.zip.file_names() {
+            if let Some(rel_path) = file_name.strip_prefix(prefix.as_str())
+                && let Some(rel_path) = rel_path.strip_suffix(suffix.as_str())
+            {
+                for component in rel_path.split("/") {
+                    if component == project.raw_project_name
+                        || component == project.project_name.as_ref()
+                    {
+                        return Ok(Cow::Borrowed(
+                            Path::new(file_name).strip_prefix(strip_prefix)?,
+                        ));
+                    }
+                }
+            }
+        }
+        bail!(
+            "Failed to find path in wheel {wheel} zip with prefix {prefix} and suffix {suffix}",
+            wheel = project.file_name,
+        )
+    }
+}
+
+fn normalized_data_dir_relpath<'a>(
+    prefix: &Path,
+    path: &'a Path,
+    wheel_file: &WheelFile,
+    project_path_finder: &'a impl ProjectPathFinder<'a>,
+) -> anyhow::Result<Cow<'a, Path>> {
     let mut components = path.components();
-    if let Some(start) = components.next()
+    let start = components.next();
+    if let Some(start) = start
         && matches!(start, Component::Normal(name) if name == "scripts")
     {
-        Cow::Owned(
+        Ok(Cow::Owned(
             [Component::Normal(OsStr::new("bin"))]
                 .into_iter()
                 .chain(components)
                 .collect(),
-        )
+        ))
+    } else if let Some(start) = start
+        && matches!(start, Component::Normal(name) if name == "headers")
+    {
+        // N.B.: You'd think sysconfig_paths["include"] would be the right answer here but both
+        // `pip`, and by emulation, `uv pip`, map `*.data/headers` to
+        // `<venv>/include/site/pythonX.Y/<project name>`. Traditional PEXes honors this; so we
+        // need to as well.
+        //
+        // The "mess" is admitted and described at length here:
+        // + https://discuss.python.org/t/clarification-on-a-wheels-header-data/9305
+        // + https://discuss.python.org/t/deprecating-the-headers-wheel-data-key/23712
+        Ok(project_path_finder.find(
+            prefix,
+            Path::new("include").join("site"),
+            wheel_file,
+            components.collect(),
+        )?)
     } else {
-        Cow::Borrowed(path)
+        Ok(Cow::Borrowed(path))
     }
 }

--- a/crates/pexrs/src/lib.rs
+++ b/crates/pexrs/src/lib.rs
@@ -152,7 +152,7 @@ pub fn mount(python: impl AsRef<Path>, pex: impl AsRef<Path>) -> anyhow::Result<
         #[cfg(unix)]
         None,
     )
-    .map(|venv| venv.site_packages_path())
+    .map(|venv| venv.prefix().join(&venv.site_packages_relpath))
 }
 
 #[time("debug", "{}")]

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -17,10 +17,29 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::{fs, io};
 
+pub enum Perms {
+    Perms(fs::Permissions),
+    Mode(u32),
+}
+
 #[cfg(unix)]
-pub use unix::{exec, is_executable, mark_executable, path_as_bytes, symlink_or_link_or_copy};
+pub use unix::{
+    exec,
+    is_executable,
+    mark_executable,
+    path_as_bytes,
+    set_permissions,
+    symlink_or_link_or_copy,
+};
 #[cfg(windows)]
-pub use windows::{exec, is_executable, mark_executable, path_as_bytes, symlink_or_link_or_copy};
+pub use windows::{
+    exec,
+    is_executable,
+    mark_executable,
+    path_as_bytes,
+    set_permissions,
+    symlink_or_link_or_copy,
+};
 
 pub fn path_as_str(path: &Path) -> io::Result<&str> {
     path.to_str().ok_or_else(|| {

--- a/crates/platform/src/unix.rs
+++ b/crates/platform/src/unix.rs
@@ -17,6 +17,8 @@ use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 use nix::unistd;
 use nix::unistd::AccessFlags;
 
+use crate::Perms;
+
 pub fn symlink_or_link_or_copy(
     src: impl AsRef<Path>,
     dst: impl AsRef<Path>,
@@ -73,10 +75,18 @@ pub fn is_executable(path: impl AsRef<Path>) -> io::Result<bool> {
 }
 
 pub fn mark_executable(file: &mut File) -> io::Result<()> {
-    let mut permissions = file.metadata()?.permissions();
-    permissions.set_mode(0o755);
-    file.set_permissions(permissions)?;
-    Ok(())
+    set_permissions(file, Perms::Mode(0o755))
+}
+
+pub fn set_permissions(file: &mut File, perms: Perms) -> io::Result<()> {
+    match perms {
+        Perms::Perms(permissions) => file.set_permissions(permissions),
+        Perms::Mode(mode) => {
+            let mut permissions = file.metadata()?.permissions();
+            permissions.set_mode(mode);
+            file.set_permissions(permissions)
+        }
+    }
 }
 
 pub fn path_as_bytes(path: &Path) -> io::Result<&[u8]> {

--- a/crates/platform/src/windows.rs
+++ b/crates/platform/src/windows.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::process::Command;

--- a/crates/platform/src/windows.rs
+++ b/crates/platform/src/windows.rs
@@ -1,12 +1,14 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::Path;
 use std::process::Command;
 
 use is_executable::IsExecutable;
+
+use crate::Perms;
 
 pub fn symlink_or_link_or_copy(
     src: impl AsRef<Path>,
@@ -20,7 +22,11 @@ pub fn is_executable(path: impl AsRef<Path>) -> io::Result<bool> {
     Ok(path.as_ref().is_executable())
 }
 
-pub fn mark_executable(_file: &mut File) -> io::Result<()> {
+pub const fn mark_executable(_file: &mut File) -> io::Result<()> {
+    Ok(())
+}
+
+pub const fn set_permissions(_file: &mut File, _perms: Perms) -> io::Result<()> {
     Ok(())
 }
 

--- a/crates/scripts/src/interpreter.py
+++ b/crates/scripts/src/interpreter.py
@@ -112,6 +112,7 @@ def identify(supported_tags):
         "macos_framework_build": macos_framework_build,
         "has_ensurepip": has_ensurepip,
         "free_threaded": free_threaded,
+        "paths": sysconfig.get_paths(),
     }
 
 

--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -251,7 +251,6 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
         venv
     };
 
-    let scripts_dir = venv.prefix().join(venv.bin_dir_relpath);
     let prompt = args
         .prompt
         .as_deref()
@@ -294,7 +293,7 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
             .replace("__PEXRC_VENV_PROMPT__", &prompt)
             .replace("__PEXRC_VENV_DIR__", &venv_dir);
 
-        fs::write(scripts_dir.join(file_name), contents)?;
+        fs::write(venv.script_path(file_name), contents)?;
     }
 
     let shebang_arg = if args.non_hermetic_scripts {

--- a/crates/venv/src/provenance.rs
+++ b/crates/venv/src/provenance.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
+use anyhow::anyhow;
 use cache::{Fingerprint, default_digest, fingerprint_file};
 use dashmap::DashMap;
 
@@ -51,10 +52,12 @@ impl Provenance {
         }
         let mut collisions = Vec::with_capacity(self.collisions.len());
         for (dst, mut collision_details) in self.collisions {
-            let (_, source) = self
-                .origins
-                .remove(&dst)
-                .expect("A collision always has a corresponding origin.");
+            let (_, source) = self.origins.remove(&dst).ok_or_else(|| {
+                anyhow!(
+                    "A collision always has a corresponding origin but {dst} has none",
+                    dst = dst.display()
+                )
+            })?;
 
             let mut srcs: BTreeMap<(Fingerprint, usize), Vec<String>> = BTreeMap::new();
             let (size, fingerprint) = fingerprint_file(&dst, default_digest())?;

--- a/crates/venv/src/venv_pex.rs
+++ b/crates/venv/src/venv_pex.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io::{BufReader, ErrorKind, Read, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -16,6 +17,7 @@ use log::warn;
 use logging_timer::time;
 use pex::{
     BinPath,
+    DataDir,
     EntryPoint,
     EntryPoints,
     Layout,
@@ -26,7 +28,7 @@ use pex::{
     collect_zipped_user_source_indexes,
     filter_zipped_user_source,
 };
-use platform::{mark_executable, path_as_bytes, path_as_str, symlink_or_link_or_copy};
+use platform::{Perms, mark_executable, path_as_bytes, path_as_str, symlink_or_link_or_copy};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use scripts::{Scripts, VenvPex, VenvPexRepl};
 use serde_json::Value;
@@ -60,39 +62,32 @@ fn populate_from_loose_pex<'a>(
     scope: InstallScope,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
-    let site_packages_path = venv.site_packages_path();
     if matches!(scope, InstallScope::All | InstallScope::Deps) {
         collect_wheels_from_directory_pex(loose_pex, resolved_wheels)?
             .into_par_iter()
-            .try_for_each(|wheel_dir| {
-                populate_wheel_dir(&wheel_dir, &site_packages_path, provenance.clone())
+            .try_for_each(|(wheel, project_name, data_dir)| {
+                populate_wheel_dir(venv, &wheel, project_name, &data_dir, provenance.clone())
             })?;
     }
     if matches!(scope, InstallScope::All | InstallScope::Srcs) {
-        populate_user_code_from_directory_pex(
-            loose_pex,
-            venv,
-            &site_packages_path,
-            populate_pex_info,
-            provenance,
-        )?;
+        populate_user_code_from_directory_pex(loose_pex, venv, populate_pex_info, provenance)?;
     }
     Ok(())
 }
 
-fn collect_wheels_from_directory_pex(
+fn collect_wheels_from_directory_pex<'a>(
     pex: &Pex,
-    resolved_wheels: &IndexMap<&str, ResolvedWheel>,
-) -> anyhow::Result<Vec<PathBuf>> {
+    resolved_wheels: &'a IndexMap<&'a str, ResolvedWheel<'a>>,
+) -> anyhow::Result<Vec<(PathBuf, &'a str, DataDir)>> {
     let mut wheels = Vec::with_capacity(resolved_wheels.len());
     let deps_dir = pex.path.join(".deps");
     if deps_dir.is_dir() {
         for entry in fs::read_dir(deps_dir)? {
             let entry = entry?;
             if let Ok(wheel_file_name) = platform::os_str_as_str(&entry.file_name())
-                && resolved_wheels.contains_key(wheel_file_name)
+                && let Some(wheel) = resolved_wheels.get(wheel_file_name)
             {
-                wheels.push(entry.path())
+                wheels.push((entry.path(), wheel.project_name, wheel.data_dir()))
             }
         }
     }
@@ -108,8 +103,7 @@ fn spread(
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
     let entry_points = virtualenv
-        .site_packages_path()
-        .join(wheel.dist_info_dir())
+        .site_packages_path(wheel.dist_info_dir())
         .join("entry_points.txt");
     if entry_points.exists() {
         install_scripts(
@@ -137,10 +131,9 @@ fn install_scripts(
         return Ok(());
     }
 
-    let script_dir = virtualenv.prefix().join(virtualenv.bin_dir_relpath);
     for (name, entry_point) in entry_points.console_scripts() {
-        let script_path = script_dir
-            .join(name)
+        let script_path = virtualenv
+            .script_path(name)
             .with_extension(env::consts::EXE_EXTENSION);
         let script_contents =
             create_script_contents(shebang_interpreter, shebang_arg, entry_point)?;
@@ -283,39 +276,107 @@ if __name__ == "__main__":
     }
 }
 
+fn calculate_spread_path(
+    venv: &Virtualenv,
+    project_name: &str,
+    data_dir: &DataDir,
+    dst_rel_path: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if let Ok(data_dir_relpath) = dst_rel_path.strip_prefix(data_dir.as_path()) {
+        let mut components = data_dir_relpath.components();
+        if let Some(paths_key) = components.next() {
+            let key = paths_key.as_os_str().to_str().ok_or_else(|| {
+                anyhow!(
+                    "The first component of .data/ dir path {path} was not a UTF-8 key into \
+                    sysconfig paths.",
+                    path = data_dir.as_path().display()
+                )
+            })?;
+            if key == "headers" {
+                // N.B.: You'd think sysconfig_paths["include"] would be the right answer here but
+                // both `pip`, and by emulation, `uv pip`, use:
+                //   `<venv>/include/site/pythonX.Y/<project name>/`.
+                //
+                // The "mess" is admitted and described at length here:
+                // + https://discuss.python.org/t/clarification-on-a-wheels-header-data/9305
+                // + https://discuss.python.org/t/deprecating-the-headers-wheel-data-key/23712
+                //
+                // Both discussions died out with no path resolved to clean up the mess.
+                Ok(Some(
+                    venv.prefix()
+                        .join("include")
+                        .join("site")
+                        .join(format!(
+                            "python{major}.{minor}",
+                            major = venv.interpreter.version.major,
+                            minor = venv.interpreter.version.minor
+                        ))
+                        .join(project_name)
+                        .join(components.collect::<PathBuf>()),
+                ))
+            } else if let Some(spread_path) = venv.interpreter.paths.get(key) {
+                Ok(Some(spread_path.join(components.collect::<PathBuf>())))
+            } else {
+                bail!(
+                    "Wheel for {project_name} has unknown .data dir entry {key}: {data_dir_relpath}",
+                    data_dir_relpath = data_dir_relpath.display()
+                )
+            }
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(Some(venv.site_packages_path(dst_rel_path)))
+    }
+}
+
 fn populate_wheel_dir(
+    venv: &Virtualenv,
     wheel: &Path,
-    site_packages_path: &Path,
+    project_name: &str,
+    data_dir: &DataDir,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
     let wheel_contents = walkdir::WalkDir::new(wheel)
         .min_depth(1)
         .into_iter()
+        .filter_map(|entry| {
+            match entry {
+                Ok(entry) => {
+                    let dst_rel_path = entry.path().strip_prefix(wheel).expect(
+                        "Walked sub-paths of a wheel dir should be child paths of the wheel dir.",
+                    );
+                    // TODO: Experiment with creating parent dirs as needed here in this synchronous loop
+                    //  just 1x to save on syscall overhead in the parallel loop over contained files below.
+                    match calculate_spread_path(venv, project_name, data_dir, dst_rel_path) {
+                        Ok(dst) => dst.map(|dst| Ok((entry, dst))),
+                        Err(err) => Some(Err(err)),
+                    }
+                }
+                Err(err) => Some(Err(anyhow!("{err}"))),
+            }
+        })
         .collect::<Result<Vec<_>, _>>()?;
-    wheel_contents.into_par_iter().try_for_each(|entry| {
-        let dst_path = site_packages_path.join(entry.path().strip_prefix(wheel).expect(
-            "Walked unpacked wheel paths should be child paths of the unpacked wheel root dir.",
-        ));
-        if entry.path().is_dir() {
-            fs::create_dir_all(&dst_path)?;
+    wheel_contents.into_par_iter().try_for_each(|(src, dst)| {
+        if src.path().is_dir() {
+            fs::create_dir_all(&dst)?;
         } else {
-            if let Some(parent_dir) = dst_path.parent() {
+            if let Some(parent_dir) = dst.parent() {
                 fs::create_dir_all(parent_dir)?;
             }
-            match File::create_new(&dst_path) {
+            match File::create_new(&dst) {
                 Ok(mut dst_file) => {
-                    provenance.record(entry.path().display(), dst_path);
-                    let mut src = File::open(entry.path())?;
+                    provenance.record(src.path().display(), dst);
+                    let mut src = File::open(src.path())?;
                     io::copy(&mut src, &mut dst_file)?;
+                    platform::set_permissions(
+                        dst_file.file_mut(),
+                        Perms::Perms(src.metadata()?.permissions()),
+                    )?;
                 }
                 Err(err) if err.kind() == ErrorKind::AlreadyExists => {
-                    let (size, fingerprint) = fingerprint_file(entry.path(), default_digest())?;
-                    provenance.record_collision(
-                        entry.path().display(),
-                        fingerprint,
-                        size,
-                        dst_path,
-                    );
+                    let (size, fingerprint) = fingerprint_file(src.path(), default_digest())?;
+                    provenance.record_collision(src.path().display(), fingerprint, size, dst);
                 }
                 Err(err) => bail!("{err}"),
             }
@@ -332,29 +393,24 @@ fn populate_from_packed_pex<'a>(
     scope: InstallScope,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
-    let site_packages_path = venv.site_packages_path();
     if matches!(scope, InstallScope::All | InstallScope::Deps) {
         collect_wheels_from_directory_pex(packed_pex, resolved_wheels)?
             .into_par_iter()
-            .try_for_each(|wheel_zip| {
-                populate_whl_zip(&wheel_zip, &site_packages_path, provenance.clone())
+            .try_for_each(|(wheel, project_name, data_dir)| {
+                populate_whl_zip(venv, &wheel, project_name, &data_dir, provenance.clone())
             })?;
     }
     if matches!(scope, InstallScope::All | InstallScope::Srcs) {
-        populate_user_code_from_directory_pex(
-            packed_pex,
-            venv,
-            &site_packages_path,
-            populate_pex_info,
-            provenance,
-        )?;
+        populate_user_code_from_directory_pex(packed_pex, venv, populate_pex_info, provenance)?;
     }
     Ok(())
 }
 
 fn populate_whl_zip(
+    venv: &Virtualenv,
     wheel: &Path,
-    site_packages_path: &Path,
+    project_name: &str,
+    data_dir: &DataDir,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
     let whl_zip = ZipArchive::new(File::open(wheel)?.into_file())?;
@@ -362,8 +418,10 @@ fn populate_whl_zip(
     (0..whl_zip.len()).into_par_iter().try_for_each(|index| {
         let zip_fp = File::open(wheel)?;
         let mut zip = unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
-        extract_idx(
-            site_packages_path,
+        extract_whl_idx(
+            venv,
+            project_name,
+            data_dir,
             index,
             &mut zip,
             wheel.display(),
@@ -375,14 +433,13 @@ fn populate_whl_zip(
 fn populate_user_code_from_directory_pex<'a>(
     directory_pex: &'a Pex<'a>,
     venv: &Virtualenv,
-    site_packages_path: &Path,
     populate_pex_info: bool,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
     let user_code = collect_loose_user_source(directory_pex.path)?;
     user_code.into_par_iter().try_for_each(|entry| {
         let dst_path =
-            site_packages_path.join(entry.path().strip_prefix(directory_pex.path).expect(
+            venv.site_packages_path(entry.path().strip_prefix(directory_pex.path).expect(
                 "Walked directory PEX paths should be child paths of the directory PEX root dir.",
             ));
         if entry.file_type().is_dir() {
@@ -429,13 +486,11 @@ fn populate_from_zip_app_with_whl_deps<'a>(
 ) -> anyhow::Result<()> {
     let pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
     let metadata = pex_zip.metadata();
-    let site_packages_path = venv.site_packages_path();
-
     if matches!(scope, InstallScope::All | InstallScope::Deps) {
         let wheel_file_names = resolved_wheels.into_iter().collect::<Vec<_>>();
         wheel_file_names
             .into_par_iter()
-            .try_for_each(|(wheel_file_name, _)| {
+            .try_for_each(|(wheel_file_name, wheel)| {
                 let zip_fp = File::open(zip_app_pex.path)?;
                 let mut zip =
                     unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
@@ -443,6 +498,7 @@ fn populate_from_zip_app_with_whl_deps<'a>(
                 let whl_file = zip.by_name_seek(&whl_name)?;
                 let whl_zip = ZipArchive::new(whl_file)?;
                 let whl_zip_metadata = whl_zip.metadata();
+                let data_dir = wheel.data_dir();
                 (0..whl_zip.len()).into_par_iter().try_for_each(|index| {
                     let zip_fp = File::open(zip_app_pex.path)?;
                     let mut zip =
@@ -451,8 +507,10 @@ fn populate_from_zip_app_with_whl_deps<'a>(
                     let mut whl_zip = unsafe {
                         ZipArchive::unsafe_new_with_metadata(whl_file, whl_zip_metadata.clone())
                     };
-                    extract_idx(
-                        &site_packages_path,
+                    extract_whl_idx(
+                        venv,
+                        wheel.project_name,
+                        &data_dir,
                         index,
                         &mut whl_zip,
                         format!("{zip}/{whl_name}", zip = zip_app_pex.path.display()),
@@ -470,8 +528,9 @@ fn populate_from_zip_app_with_whl_deps<'a>(
                 let mut zip =
                     unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
                 extract_idx(
-                    &site_packages_path,
+                    venv,
                     index,
+                    None,
                     &mut zip,
                     zip_app_pex.path.display(),
                     provenance.clone(),
@@ -491,13 +550,15 @@ fn populate_from_zip_app_with_whl_deps<'a>(
 struct DepFilter<'a>(&'a IndexMap<&'a str, ResolvedWheel<'a>>);
 
 impl<'a> DepFilter<'a> {
-    fn filter_deps(&self, file_name: &str) -> bool {
-        file_name.starts_with(".deps/")
-            && file_name[6..]
+    fn filter_deps<'b>(&self, file_name: &'b str) -> Option<&'b str> {
+        if !file_name.starts_with(".deps/") {
+            None
+        } else {
+            file_name[6..]
                 .split("/")
                 .next()
-                .map(|whl_name| self.0.contains_key(whl_name))
-                .unwrap_or_default()
+                .filter(|&whl_name| self.0.contains_key(whl_name))
+        }
     }
 }
 
@@ -512,39 +573,70 @@ fn populate_from_zip_app<'a>(
     let mut pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
     let metadata = pex_zip.metadata();
     let dep_filter = DepFilter(resolved_wheels);
-    let extract_indexes = pex_zip
-        .file_names()
-        .enumerate()
-        .filter_map(|(idx, name)| {
-            // TODO: XXX: Deal with .layout and .prefix/ in wheel chroots.
-            if match scope {
-                InstallScope::All => {
-                    dep_filter.filter_deps(name) || filter_zipped_user_source(name)
+    if matches!(scope, InstallScope::All | InstallScope::Deps) {
+        let data_dirs = resolved_wheels
+            .iter()
+            .map(|(file_name, wheel)| (*file_name, (wheel.project_name, wheel.data_dir())))
+            .collect::<HashMap<_, _>>();
+        let extract_indexes = pex_zip
+            .file_names()
+            .enumerate()
+            .filter_map(|(idx, name)| {
+                dep_filter.filter_deps(name).map(|file_name| {
+                    let (project_name, data_dir) = data_dirs
+                        .get(file_name)
+                        .expect("We mapped a data dir for each wheel file name.");
+                    (idx, project_name, data_dir)
+                })
+            })
+            .collect::<Vec<_>>();
+        extract_indexes.into_par_iter().try_for_each(
+            |(index, project_name, data_dir)| -> anyhow::Result<()> {
+                let zip_fp = File::open(zip_app_pex.path)?;
+                let mut zip =
+                    unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
+                extract_whl_idx(
+                    venv,
+                    project_name,
+                    data_dir,
+                    index,
+                    &mut zip,
+                    zip_app_pex.path.display(),
+                    provenance.clone(),
+                )?;
+                Ok(())
+            },
+        )?;
+    }
+    if matches!(scope, InstallScope::All | InstallScope::Srcs) {
+        let extract_indexes = pex_zip
+            .file_names()
+            .enumerate()
+            .filter_map(|(idx, name)| {
+                if filter_zipped_user_source(name) {
+                    Some(idx)
+                } else {
+                    None
                 }
-                InstallScope::Deps => dep_filter.filter_deps(name),
-                InstallScope::Srcs => filter_zipped_user_source(name),
-            } {
-                Some(idx)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    let site_packages_path = venv.site_packages_path();
-    extract_indexes
-        .into_par_iter()
-        .try_for_each(|index| -> anyhow::Result<()> {
-            let zip_fp = File::open(zip_app_pex.path)?;
-            let mut zip = unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
-            extract_idx(
-                &site_packages_path,
-                index,
-                &mut zip,
-                zip_app_pex.path.display(),
-                provenance.clone(),
-            )?;
-            Ok(())
-        })?;
+            })
+            .collect::<Vec<_>>();
+        extract_indexes
+            .into_par_iter()
+            .try_for_each(|index| -> anyhow::Result<()> {
+                let zip_fp = File::open(zip_app_pex.path)?;
+                let mut zip =
+                    unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
+                extract_idx(
+                    venv,
+                    index,
+                    None,
+                    &mut zip,
+                    zip_app_pex.path.display(),
+                    provenance.clone(),
+                )?;
+                Ok(())
+            })?;
+    }
     if populate_pex_info && matches!(scope, InstallScope::All | InstallScope::Srcs) {
         let mut pex_info_src_fp = pex_zip.by_name("PEX-INFO")?;
         let mut pex_info_dst_fp = File::create_new(venv.prefix().join("PEX-INFO"))?;
@@ -669,8 +761,10 @@ pub fn populate<'a>(
     Ok(())
 }
 
-fn extract_idx<R>(
-    dst_dir: impl AsRef<Path>,
+fn extract_whl_idx<R>(
+    venv: &Virtualenv,
+    project_name: &str,
+    data_dir: &DataDir,
     index: usize,
     zip: &mut ZipArchive<R>,
     source: impl Display,
@@ -679,17 +773,42 @@ fn extract_idx<R>(
 where
     R: Read + Seek,
 {
-    let mut zip_file = zip.by_index(index)?;
-    let dst_path =
-        dst_dir
-            .as_ref()
-            .join(if zip_file.name().starts_with(".deps/") {
+    let dst_path = {
+        let zip_file = zip.by_index(index)?;
+        let dst_rel_path =
+            if zip_file.name().starts_with(".deps/") {
                 zip_file.name().splitn(3, "/").nth(2).ok_or_else(|| {
                     anyhow!("Invalid PEX .deps/ entry {name}", name = zip_file.name())
                 })?
             } else {
                 zip_file.name()
-            });
+            }
+            .split("/")
+            .collect::<PathBuf>();
+        calculate_spread_path(venv, project_name, data_dir, &dst_rel_path)?
+    };
+    if dst_path.is_some() {
+        extract_idx(venv, index, dst_path, zip, source, provenance)
+    } else {
+        Ok(())
+    }
+}
+
+fn extract_idx<R>(
+    venv: &Virtualenv,
+    index: usize,
+    dst_path: Option<PathBuf>,
+    zip: &mut ZipArchive<R>,
+    source: impl Display,
+    provenance: Arc<Provenance>,
+) -> anyhow::Result<()>
+where
+    R: Read + Seek,
+{
+    let mut zip_file = zip.by_index(index)?;
+    let dst_path = dst_path.unwrap_or_else(|| {
+        venv.site_packages_path(zip_file.name().split("/").collect::<PathBuf>())
+    });
     if zip_file.is_dir() {
         fs::create_dir_all(dst_path)?;
     } else {
@@ -700,6 +819,9 @@ where
             Ok(mut dst_file) => {
                 provenance.record(format!("{source}/{name}", name = zip_file.name()), dst_path);
                 io::copy(&mut zip_file, &mut dst_file)?;
+                if let Some(mode) = zip_file.unix_mode() {
+                    platform::set_permissions(dst_file.file_mut(), Perms::Mode(mode))?;
+                }
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {
                 let size = usize::try_from(zip_file.size())?;

--- a/crates/venv/src/virtualenv.rs
+++ b/crates/venv/src/virtualenv.rs
@@ -69,7 +69,7 @@ impl Linker for FileSystemLinker {
 pub struct Virtualenv<'a> {
     pub interpreter: Interpreter,
     pub bin_dir_relpath: &'a str,
-    site_packages_relpath: Cow<'a, Path>,
+    pub site_packages_relpath: Cow<'a, Path>,
 }
 
 impl<'a> Virtualenv<'a> {
@@ -107,6 +107,11 @@ impl<'a> Virtualenv<'a> {
         venv_interpreter.path = venv_dir.join(executable_relpath.as_ref());
         if HOST.operating_system == OperatingSystem::Windows {
             venv_interpreter.realpath = venv_interpreter.path.clone();
+        }
+        for path in venv_interpreter.paths.values_mut() {
+            if let Ok(prefix_rel_path) = path.strip_prefix(&interpreter.prefix) {
+                *path = venv_interpreter.prefix.join(prefix_rel_path);
+            }
         }
         Ok(venv_interpreter)
     }
@@ -158,8 +163,18 @@ impl<'a> Virtualenv<'a> {
         &self.interpreter.prefix
     }
 
-    pub fn site_packages_path(&self) -> PathBuf {
-        self.interpreter.prefix.join(&self.site_packages_relpath)
+    pub fn script_path(&self, rel_path: impl AsRef<Path>) -> PathBuf {
+        self.interpreter
+            .prefix
+            .join(self.bin_dir_relpath)
+            .join(rel_path)
+    }
+
+    pub fn site_packages_path(&self, rel_path: impl AsRef<Path>) -> PathBuf {
+        self.interpreter
+            .prefix
+            .join(self.site_packages_relpath.as_ref())
+            .join(rel_path)
     }
 
     pub fn create_additional_pythons(&self) -> anyhow::Result<()> {
@@ -340,8 +355,15 @@ fn create_pep_405_venv<'a>(
     let site_packages_relpath = site_packages_relpath(&base_interpreter);
     fs::create_dir_all(path.join(site_packages_relpath.as_ref()))?;
     if pip {
-        // The ensurepip module is optional, consider embedding or fetching:
-        // https://bootstrap.pypa.io/pip/
+        if !base_interpreter.has_ensurepip {
+            // TODO: Consider embedding or fetching: https://bootstrap.pypa.io/pip/
+            bail!(
+                "Cannot install Pip since the selected interpreter does not have the `ensurepip` \
+                module: {interpreter}",
+                interpreter = base_interpreter.path.display()
+            )
+        }
+
         Command::new(dest)
             .args(["-m", "ensurepip", "--default-pip"])
             .stdout(Stdio::null())


### PR DESCRIPTION
The `pexrc` tool now "un-spreads" legacy PEX wheel chroots and, at
runtime, installation of wheels in venvs includes a proper spread
operation.