### PR TITLE
Bring `--sh-boot` python list to parity with Pex.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
         run: |
           chmod +x target/release/package
           export CARGO="$(command -v cargo)"
-          PEXRC_CLIB_FEATURES=tools target/release/package \
-            --color always --profile release -o dist ${{ matrix.targets }}
+          target/release/package \
+            --color always --profile release --tools -o dist ${{ matrix.targets }}
       - name: Generate Release Hashes Manifest.
         run: uv run dev-cmd --color always generate-release-hashes -- -i dist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,8 @@ jobs:
         run: |
           chmod +x target/release/package
           export CARGO="$(command -v cargo)"
-          PEXRC_CLIB_FEATURES=tools target/release/package \
-            --color always --profile release -o dist --target ${{ matrix.target }}
+          target/release/package \
+            --color always --profile release --tools -o dist --target ${{ matrix.target }}
       - name: Upload pexrc artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.9.2
+
+This release fixes injected `--sh-boot` PEXes to have the same interpreter selection logic as PEX.
+
 ## 0.9.1
 
 This release fixes injected PEXes to properly resolve from legacy PEXes on the PEX_PATH at runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.9.1"
+version = "0.9.2"
 edition = { workspace = true }
 publish = false
 

--- a/crates/boot/src/boot.sh
+++ b/crates/boot/src/boot.sh
@@ -83,7 +83,7 @@ echo >&2 "Failed to find any of these python binaries on the PATH:"
 for python in ${PYTHONS} ; do
     echo >&2 "${python}"
 done
-echo >&2 "Either adjust your \$PATH which is currently:"
+echo >&2 "Either adjust your PATH, which is currently:"
 echo >&2 "${PATH}"
 echo >&2 "Or else install an appropriate Python that provides one of the binaries in this list."
 exit 1

--- a/crates/boot/src/lib.rs
+++ b/crates/boot/src/lib.rs
@@ -11,7 +11,13 @@ use cache::CacheDir;
 use const_format::str_split;
 use fs_err as fs;
 use fs_err::File;
-use interpreter::{InterpreterConstraints, SearchPath, SelectionStrategy, VersionSpec};
+use interpreter::{
+    Interpreter,
+    InterpreterConstraints,
+    SearchPath,
+    SelectionStrategy,
+    VersionSpec,
+};
 use itertools::Itertools;
 use pex::{Pex, PexPath};
 use pexrs::venv_dir;
@@ -23,12 +29,11 @@ const SH_BOOT_SHEBANG: &[u8] = b"#!/bin/sh\n";
 const SH_BOOT_PARTS: [&str; 4] = str_split!(include_str!("boot.sh"), "# --- split --- #\n");
 
 pub fn sh_boot_shebang(
-    pex: &Path,
+    pex: &Pex,
     hermetic: bool,
     escaped: bool,
+    preferred_interpreter: Option<&Interpreter>,
 ) -> anyhow::Result<Option<String>> {
-    let pex = Pex::load(pex)?;
-
     let mut sh_boot_shebang_buffer: [_; SH_BOOT_SHEBANG.len()] = [0; SH_BOOT_SHEBANG.len()];
     let mut pex_fp = File::open(pex.file())?;
     match pex_fp.read_exact(&mut sh_boot_shebang_buffer) {
@@ -46,7 +51,7 @@ pub fn sh_boot_shebang(
     let pex_path = PexPath::from_pex_info(&pex.info, false);
     let additional_pexes = pex_path.load_pexes()?;
 
-    let venv_dir = venv_dir(None, &pex, &SearchPath::EMPTY, &additional_pexes)?;
+    let venv_dir = venv_dir(None, pex, &SearchPath::EMPTY, &additional_pexes)?;
     let venv_relpath = venv_dir.strip_prefix(CacheDir::root()?)?;
 
     let interpreter_constraints =
@@ -58,7 +63,7 @@ pub fn sh_boot_shebang(
         .unwrap_or(pex::InterpreterSelectionStrategy::Oldest)
         .into();
     let pythons = interpreter_constraints
-        .calculate_compatible_binary_names(selection_strategy)
+        .calculate_compatible_binary_names(selection_strategy, preferred_interpreter)
         .into_iter()
         .map(|(binary_name, version_spec)| {
             binary_name

--- a/crates/interpreter/src/constraints.rs
+++ b/crates/interpreter/src/constraints.rs
@@ -102,11 +102,6 @@ pub struct InterpreterConstraint {
 }
 
 impl InterpreterConstraint {
-    const ANY: Self = Self {
-        implementation: None,
-        version_specifiers: None,
-    };
-
     pub fn exact_version(interpreter: &Interpreter) -> Self {
         let python_version = Version::new(
             [
@@ -315,80 +310,40 @@ impl InterpreterConstraints {
     fn calculate_compatible_binary_specs(
         &self,
         selection_strategy: SelectionStrategy,
+        preferred_interpreter: Option<&Interpreter>,
     ) -> IndexSet<PythonBinarySpec> {
-        let versions = match selection_strategy {
-            SelectionStrategy::Oldest => &SUPPORTED_VERSIONS,
-            SelectionStrategy::Newest => &SUPPORTED_VERSIONS_NEWEST_FIRST,
-        };
-        let constraints = if self.0.is_empty() {
-            &[InterpreterConstraint::ANY]
-        } else {
-            self.0.as_slice()
-        };
         let mut binary_specs: IndexSet<PythonBinarySpec> = IndexSet::new();
-        for (major, minor) in versions.iter() {
-            for constraint in constraints {
-                if constraint.contains_version(*major, *minor) {
-                    match constraint.implementation.as_ref() {
-                        None => {
-                            binary_specs.insert(PythonBinarySpec {
-                                name: "python",
-                                major: *major,
-                                minor: *minor,
-                                suffix: None,
-                            });
-                            if (*major, *minor) >= (3, 13) {
-                                binary_specs.insert(PythonBinarySpec {
-                                    name: "python",
-                                    major: *major,
-                                    minor: *minor,
-                                    suffix: Some("t"),
-                                });
-                            }
-                            binary_specs.insert(PythonBinarySpec {
-                                name: "pypy",
-                                major: *major,
-                                minor: *minor,
-                                suffix: None,
-                            });
-                        }
-                        Some(implementation) => match implementation {
-                            InterpreterImplementation::CPython
-                            | InterpreterImplementation::CPythonGil => {
-                                binary_specs.insert(PythonBinarySpec {
-                                    name: "python",
-                                    major: *major,
-                                    minor: *minor,
-                                    suffix: None,
-                                });
-                            }
-                            InterpreterImplementation::CPythonFreeThreaded => {
-                                if (*major, *minor) >= (3, 13) {
-                                    binary_specs.insert(PythonBinarySpec {
-                                        name: "python",
-                                        major: *major,
-                                        minor: *minor,
-                                        suffix: Some("t"),
-                                    });
-                                } else {
-                                    debug!(
-                                        "Ignoring {constraint} for CPython {major}.{minor} since \
-                                        free-threaded CPython only exists for >=3.13."
-                                    );
-                                }
-                            }
-                            InterpreterImplementation::PyPy => {
-                                binary_specs.insert(PythonBinarySpec {
-                                    name: "pypy",
-                                    major: *major,
-                                    minor: *minor,
-                                    suffix: None,
-                                });
-                            }
-                        },
+        if let Some(interpreter) = preferred_interpreter
+            && self.contains(interpreter)
+        {
+            let implementation = InterpreterImplementation::of(interpreter);
+            insert_specs(
+                &mut binary_specs,
+                implementation.as_ref(),
+                interpreter.raw().version.major,
+                interpreter.raw().version.minor,
+            );
+        }
+        if !self.0.is_empty() {
+            let versions = match selection_strategy {
+                SelectionStrategy::Oldest => &SUPPORTED_VERSIONS,
+                SelectionStrategy::Newest => &SUPPORTED_VERSIONS_NEWEST_FIRST,
+            };
+            for (major, minor) in versions.iter() {
+                for constraint in &self.0 {
+                    if constraint.contains_version(*major, *minor) {
+                        insert_specs(
+                            &mut binary_specs,
+                            constraint.implementation.as_ref(),
+                            *major,
+                            *minor,
+                        );
                     }
                 }
             }
+        }
+        for (major, minor) in SUPPORTED_VERSIONS_NEWEST_FIRST.iter() {
+            insert_specs(&mut binary_specs, None, *major, *minor);
         }
         binary_specs
     }
@@ -396,8 +351,10 @@ impl InterpreterConstraints {
     pub fn calculate_compatible_binary_names(
         &self,
         selection_strategy: SelectionStrategy,
+        preferred_interpreter: Option<&Interpreter>,
     ) -> IndexMap<OsString, Option<VersionSpec>> {
-        let binary_specs = self.calculate_compatible_binary_specs(selection_strategy);
+        let binary_specs =
+            self.calculate_compatible_binary_specs(selection_strategy, preferred_interpreter);
         let mut binary_names: IndexMap<OsString, Option<VersionSpec>> = IndexMap::new();
         for binary_spec in &binary_specs {
             binary_names.insert(
@@ -441,7 +398,7 @@ impl InterpreterConstraints {
         let binary_names = if let Some(python) = python {
             vec![python]
         } else {
-            self.calculate_compatible_binary_names(selection_strategy)
+            self.calculate_compatible_binary_names(selection_strategy, None)
                 .into_keys()
                 .collect()
         };
@@ -453,6 +410,71 @@ impl InterpreterConstraints {
             binary_paths: None,
             seen: HashSet::new(),
         })
+    }
+}
+
+fn insert_specs(
+    binary_specs: &mut IndexSet<PythonBinarySpec>,
+    implementation: Option<&InterpreterImplementation>,
+    major: u8,
+    minor: u8,
+) {
+    match implementation {
+        None => {
+            binary_specs.insert(PythonBinarySpec {
+                name: "python",
+                major,
+                minor,
+                suffix: None,
+            });
+            if (major, minor) >= (3, 13) {
+                binary_specs.insert(PythonBinarySpec {
+                    name: "python",
+                    major,
+                    minor,
+                    suffix: Some("t"),
+                });
+            }
+            binary_specs.insert(PythonBinarySpec {
+                name: "pypy",
+                major,
+                minor,
+                suffix: None,
+            });
+        }
+        Some(implementation) => match implementation {
+            InterpreterImplementation::CPython | InterpreterImplementation::CPythonGil => {
+                binary_specs.insert(PythonBinarySpec {
+                    name: "python",
+                    major,
+                    minor,
+                    suffix: None,
+                });
+            }
+            InterpreterImplementation::CPythonFreeThreaded => {
+                if (major, minor) >= (3, 13) {
+                    binary_specs.insert(PythonBinarySpec {
+                        name: "python",
+                        major,
+                        minor,
+                        suffix: Some("t"),
+                    });
+                } else {
+                    debug!(
+                        "Ignoring free-threaded constraint for CPython {major}.{minor} since \
+                        free-threaded CPython only exists for >=3.13."
+                    );
+                }
+            }
+            InterpreterImplementation::PyPy => {
+                binary_specs.insert(PythonBinarySpec {
+                    name: "pypy",
+                    major,
+                    minor,
+                    suffix: None,
+                });
+            }
+        },
     }
 }
 
@@ -619,58 +641,67 @@ mod tests {
         unsafe { OsStr::from_encoded_bytes_unchecked(value.as_bytes()) }
     }
 
+    // N.B.: As time advances, the supported set by PEXrc will steadily add python3.16, etc to
+    // the top of this list per https://peps.python.org/pep-0602/ (c.f. code above); so we just
+    // check a known run as of this test writing.
+    const EXPECTED_PER_PEXRC_MAJOR_MINOR: &[&str] = &[
+        "python3.15",
+        "python3.15t",
+        "pypy3.15",
+        "python3.14",
+        "python3.14t",
+        "pypy3.14",
+        "python3.13",
+        "python3.13t",
+        "pypy3.13",
+        "python3.12",
+        "pypy3.12",
+        "python3.11",
+        "pypy3.11",
+        "python3.10",
+        "pypy3.10",
+        "python3.9",
+        "pypy3.9",
+        "python3.8",
+        "pypy3.8",
+        "python3.7",
+        "pypy3.7",
+        "python3.6",
+        "pypy3.6",
+        "python3.5",
+        "pypy3.5",
+        "python2.7",
+        "pypy2.7",
+    ];
+
+    const EXPECTED_PER_PEXRC_REST: &[&str] =
+        &["python3", "pypy3", "python2", "pypy2", "python", "pypy"];
+
     #[test]
     fn test_interpreter_constraints_binary_names_all_default_order() {
         let ics = InterpreterConstraints::try_from::<&str>(&[]).unwrap();
         let binary_names = ics
-            .calculate_compatible_binary_names(SelectionStrategy::Oldest)
+            .calculate_compatible_binary_names(SelectionStrategy::Oldest, None)
             .into_keys()
             .collect::<IndexSet<_>>();
 
-        assert_eq!(&["python2.7", "pypy2.7"], &binary_names[0..2]);
+        let major_minor_start = binary_names.len()
+            - EXPECTED_PER_PEXRC_REST.len()
+            - EXPECTED_PER_PEXRC_MAJOR_MINOR.len();
+        let rest_start = binary_names.len() - EXPECTED_PER_PEXRC_REST.len();
 
-        assert!(
-            binary_names.get_index_of(os_str("pypy2.7"))
-                < binary_names.get_index_of(os_str("python3.14"))
-        );
-        assert!(
-            binary_names.get_index_of(os_str("python3.14"))
-                < binary_names.get_index_of(os_str("pypy3.14"))
-        );
-        assert!(
-            binary_names.get_index_of(os_str("pypy3.14"))
-                < binary_names.get_index_of(os_str("python3.15"))
-        );
-        assert!(
-            binary_names.get_index_of(os_str("python3.15"))
-                < binary_names.get_index_of(os_str("pypy3.15"))
-        );
         assert_eq!(
-            &["python2", "pypy2", "python3", "pypy3", "python", "pypy"],
-            &binary_names[binary_names.len() - 6..]
+            EXPECTED_PER_PEXRC_MAJOR_MINOR,
+            &binary_names[major_minor_start..rest_start]
         );
-
-        assert!(!binary_names.contains(os_str("python2.6")));
-        assert!(!binary_names.contains(os_str("python2.8")));
-        assert!(!binary_names.contains(os_str("python3.0")));
-        assert!(!binary_names.contains(os_str("python3.1")));
-        assert!(!binary_names.contains(os_str("python3.2")));
-        assert!(!binary_names.contains(os_str("python3.3")));
-        assert!(!binary_names.contains(os_str("python3.4")));
-        assert!(binary_names.contains(os_str("python3.5")));
-        assert!(binary_names.contains(os_str("python3.6")));
-
-        assert!(!binary_names.contains(os_str("python3.12t")));
-        assert!(binary_names.contains(os_str("python3.13t")));
-        assert!(binary_names.contains(os_str("python3.14t")));
-        assert!(binary_names.contains(os_str("python3.15t")));
+        assert_eq!(EXPECTED_PER_PEXRC_REST, &binary_names[rest_start..]);
     }
 
     #[test]
     fn test_interpreter_constraints_binary_names_all_newest_first() {
         let ics = InterpreterConstraints::try_from::<&str>(&[]).unwrap();
         let binary_names = ics
-            .calculate_compatible_binary_names(SelectionStrategy::Newest)
+            .calculate_compatible_binary_names(SelectionStrategy::Newest, None)
             .into_keys()
             .collect::<IndexSet<_>>();
 
@@ -716,43 +747,62 @@ mod tests {
         ])
         .unwrap();
 
+        let binary_names = ics
+            .calculate_compatible_binary_names(SelectionStrategy::Newest, None)
+            .into_keys()
+            .collect::<Vec<_>>();
+
+        let expected_per_ics = &[
+            "python3.15t",
+            "python3.14t",
+            "python3.13",
+            "python3.12",
+            "pypy3.11",
+            "pypy3.10",
+            "pypy3.9",
+        ];
+
+        let expexcted_per_pexrc_major_minor = EXPECTED_PER_PEXRC_MAJOR_MINOR
+            .into_iter()
+            .filter(|name| !expected_per_ics.contains(name))
+            .copied()
+            .collect::<Vec<_>>();
+
+        let major_minor_start = binary_names.len()
+            - EXPECTED_PER_PEXRC_REST.len()
+            - expexcted_per_pexrc_major_minor.len();
+        let rest_start = binary_names.len() - EXPECTED_PER_PEXRC_REST.len();
+
+        assert_eq!(expected_per_ics, &binary_names[..expected_per_ics.len()]);
         assert_eq!(
-            &[
-                "python3.15t",
-                "python3.14t",
-                "python3.13",
-                "python3.12",
-                "pypy3.11",
-                "pypy3.10",
-                "pypy3.9",
-                "python3",
-                "pypy3",
-                "python",
-                "pypy",
-            ],
-            ics.calculate_compatible_binary_names(SelectionStrategy::Newest)
-                .into_keys()
-                .collect::<Vec<_>>()
-                .as_slice()
+            expexcted_per_pexrc_major_minor,
+            &binary_names[major_minor_start..rest_start]
         );
+        assert_eq!(EXPECTED_PER_PEXRC_REST, &binary_names[rest_start..]);
+
+        let binary_names = ics
+            .calculate_compatible_binary_names(SelectionStrategy::Oldest, None)
+            .into_keys()
+            .collect::<Vec<_>>();
+
+        let expected_per_ics = &[
+            "pypy3.9",
+            "pypy3.10",
+            "pypy3.11",
+            "python3.12",
+            "python3.13",
+            "python3.14t",
+            "python3.15t",
+        ];
+        let expected_shared = &["pypy3", "python3", "python2", "pypy2", "pypy", "python"];
+
+        let rest_start = binary_names.len() - expected_shared.len();
+
+        assert_eq!(expected_per_ics, &binary_names[..expected_per_ics.len()]);
         assert_eq!(
-            &[
-                "pypy3.9",
-                "pypy3.10",
-                "pypy3.11",
-                "python3.12",
-                "python3.13",
-                "python3.14t",
-                "python3.15t",
-                "pypy3",
-                "python3",
-                "pypy",
-                "python",
-            ],
-            ics.calculate_compatible_binary_names(SelectionStrategy::Oldest)
-                .into_keys()
-                .collect::<Vec<_>>()
-                .as_slice()
+            expexcted_per_pexrc_major_minor,
+            &binary_names[major_minor_start..rest_start]
         );
+        assert_eq!(expected_shared, &binary_names[rest_start..]);
     }
 }

--- a/crates/package/src/main.rs
+++ b/crates/package/src/main.rs
@@ -103,6 +103,9 @@ struct Cli {
     #[arg(value_parser=clap::builder::PossibleValuesParser::new(AVAILABLE_TARGETS.iter()))]
     targets: Vec<String>,
 
+    #[arg(short = 't', visible_alias = "tools", long, default_value = "false")]
+    include_tools: bool,
+
     #[arg(short = 'o', long)]
     dist_dir: Option<PathBuf>,
 
@@ -170,10 +173,15 @@ fn main() -> anyhow::Result<()> {
         (profile, None)
     };
 
+    let mut env = vec![("PEXRC_TARGETS", "all")];
+    if cli.include_tools {
+        env.push(("PEXRC_CLIB_FEATURES", "tools"));
+    }
+
     let built = if cli.targets.is_empty() {
         let result = Command::new(cargo)
             .args(["build", "--profile", profile])
-            .env("PEXRC_TARGETS", "all")
+            .envs(env)
             .spawn()?
             .wait()?;
         if !result.success() {
@@ -210,7 +218,7 @@ fn main() -> anyhow::Result<()> {
                     target.fully_qualified_binary_name("pexrc", profile_target_suffix)?,
                 ));
             }
-            command.env("PEXRC_TARGETS", "all");
+            command.envs(env.clone());
             for found_tool in &found_tools {
                 command.env(found_tool.env_var, &found_tool.path);
             }
@@ -237,7 +245,7 @@ fn main() -> anyhow::Result<()> {
                     target.fully_qualified_binary_name("pexrc", profile_target_suffix)?,
                 ));
             }
-            command.env("PEXRC_TARGETS", "all");
+            command.envs(env);
             for found_tool in &found_tools {
                 command.env(found_tool.env_var, &found_tool.path);
             }

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -116,6 +116,9 @@ enum Commands {
         #[arg(action=ArgAction::Append)]
         targets: Vec<SimplifiedTarget>,
 
+        #[arg(short = 'p', long)]
+        preferred_python: Option<PathBuf>,
+
         #[arg(value_name = "PEX", required = true)]
         pexes: Vec<String>,
     },
@@ -175,6 +178,7 @@ fn main() -> anyhow::Result<()> {
             compression_method,
             compression_level,
             targets,
+            preferred_python,
             pexes,
         } => {
             let (clibs, proxies) = if !targets.is_empty() {
@@ -211,6 +215,7 @@ fn main() -> anyhow::Result<()> {
                 &WheelOptions::new(compression_method.into(), compression_level, None),
                 clibs.as_slice(),
                 proxies.as_slice(),
+                preferred_python.as_deref(),
             )
         }
         Commands::Info => info::display(),

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -15,12 +15,13 @@ use enumset::EnumSet;
 use fs_err as fs;
 use fs_err::File;
 use indexmap::IndexSet;
+use interpreter::Interpreter;
 use log::info;
 use owo_colors::OwoColorize;
 use pex::{Layout, Pex, WheelFile, WheelOptions};
 use platform::mark_executable;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use scripts::Scripts;
+use scripts::{IdentifyInterpreter, Scripts};
 use target::SimplifiedTarget;
 use tempfile::NamedTempFile;
 use zip::write::SimpleFileOptions;
@@ -33,9 +34,10 @@ pub fn inject_all(
     options: &WheelOptions,
     clibs: &[&Binary],
     proxies: &[&Binary],
+    preferred_python: Option<&Path>,
 ) -> anyhow::Result<()> {
     for pex in pexes {
-        inject(&pex, options, clibs, proxies)?
+        inject(&pex, options, clibs, proxies, preferred_python)?
     }
     Ok(())
 }
@@ -148,14 +150,25 @@ fn inject(
     options: &WheelOptions,
     clibs: &[&Binary],
     proxies: &[&Binary],
+    preferred_python: Option<&Path>,
 ) -> anyhow::Result<()> {
     let pex = Pex::load(pex)?;
     let required_targets = RequiredTargets::for_pex(&pex)?;
     let clibs = required_targets.select_binaries(clibs)?;
     let proxies = required_targets.select_binaries(proxies)?;
+    let preferred_interpreter = if let Some(python) = preferred_python {
+        let identification_script = IdentifyInterpreter::read(&mut Scripts::Embedded)?;
+        Some(Interpreter::load(python, &identification_script)?)
+    } else {
+        None
+    };
     match pex.layout {
-        Layout::Loose | Layout::Packed => inject_pex_dir(pex, options, clibs, proxies),
-        Layout::ZipApp => inject_pex_zip(pex, options, clibs, proxies),
+        Layout::Loose | Layout::Packed => {
+            inject_pex_dir(pex, options, clibs, proxies, preferred_interpreter.as_ref())
+        }
+        Layout::ZipApp => {
+            inject_pex_zip(pex, options, clibs, proxies, preferred_interpreter.as_ref())
+        }
     }
 }
 
@@ -164,12 +177,16 @@ fn inject_pex_dir(
     options: &WheelOptions,
     clibs: IndexSet<&Binary>,
     proxies: IndexSet<&Binary>,
+    preferred_interpreter: Option<&Interpreter>,
 ) -> anyhow::Result<()> {
     // Make sure we have a shebang early. This partially validates the pex to inject is a valid one
     // before expending too much effort copying files below.
-    let shebang = if let Some(sh_boot_shebang) =
-        sh_boot_shebang(pex.path, pex.info.raw().venv_hermetic_scripts, true)?
-    {
+    let shebang = if let Some(sh_boot_shebang) = sh_boot_shebang(
+        &pex,
+        pex.info.raw().venv_hermetic_scripts,
+        true,
+        preferred_interpreter,
+    )? {
         sh_boot_shebang
     } else {
         let original_main = pex.path.join("__main__.py");
@@ -297,13 +314,17 @@ fn inject_pex_zip(
     options: &WheelOptions,
     clibs: IndexSet<&Binary>,
     proxies: IndexSet<&Binary>,
+    preferred_interpreter: Option<&Interpreter>,
 ) -> anyhow::Result<()> {
     let pex_info = pex.info.raw();
     let zip_read_fp = File::open(pex.path)?;
     let mut src_zip = ZipArchive::new(&zip_read_fp)?;
-    let prefix = if let Some(sh_boot_shebang) =
-        sh_boot_shebang(pex.path, pex_info.venv_hermetic_scripts, false)?
-    {
+    let prefix = if let Some(sh_boot_shebang) = sh_boot_shebang(
+        &pex,
+        pex_info.venv_hermetic_scripts,
+        false,
+        preferred_interpreter,
+    )? {
         Some(sh_boot_shebang.into_bytes())
     } else {
         let first_entry = src_zip.by_index(0)?;


### PR DESCRIPTION
Previously `pexrc inject` did not support a preferred interpreter (the
current interpreter when building with Pex) and it did not back-fill all
the interpreters supported by the Pex runtime itself.