### PR TITLE
Honor `PEX_ROOT` if `PEXRC_ROOT` not set.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.10.0
+
+This release adds support for `PEX_ROOT`. When `PEXRC_ROOT` is set in the environment, it is still
+preferred, but if not, a subdir of `PEX_ROOT` will be used to house the pexrc cache.
+
+Additionally, if the final calculated pexrc cache root is not writable, a temporary cache dir will
+be established and a warning issued just as is the case for Pex.
+
 ## 0.9.2
 
 This release fixes injected `--sh-boot` PEXes to have the same interpreter selection logic as PEX.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,8 +250,10 @@ dependencies = [
  "base64",
  "digest 0.11.2",
  "dirs",
+ "dtor",
  "fs-err",
  "hex",
+ "log",
  "logging_timer",
  "sha2 0.11.0",
  "tempfile",
@@ -2036,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.9.2"
+version = "0.10.0"
 edition = { workspace = true }
 publish = false
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -11,8 +11,10 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 dirs = { workspace = true }
 digest = { workspace = true }
+dtor = { workspace = true }
 fs-err = { workspace = true }
 hex = { workspace = true }
+log = { workspace = true }
 logging_timer = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -8,12 +8,14 @@ mod fingerprint;
 mod key;
 
 use std::borrow::Cow;
-use std::env;
-use std::path::{Path, PathBuf};
+use std::ops::Deref;
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
+use std::{env, fs};
 
 use anyhow::anyhow;
 pub use atomic::{atomic_dir, atomic_file};
+use dtor::dtor;
 pub use fingerprint::{
     DigestingReader,
     Fingerprint,
@@ -23,7 +25,9 @@ pub use fingerprint::{
     hash_file,
 };
 pub use key::Key;
+use log::{debug, warn};
 use logging_timer::time;
+use tempfile::TempDir;
 
 pub fn cache_dir(name: &str, alt_name: &str) -> Option<PathBuf> {
     if let Some(cache_dir) = dirs::cache_dir() {
@@ -33,25 +37,95 @@ pub fn cache_dir(name: &str, alt_name: &str) -> Option<PathBuf> {
     }
 }
 
-static PEXRC_ROOT: LazyLock<Result<PathBuf, Cow<'static, str>>> = LazyLock::new(|| {
-    if let Some(pexrc_root) = env::var_os("PEXRC_ROOT") {
-        let path = Path::new(&pexrc_root);
-        let components = path.components();
-        let mut cache_dir = PathBuf::with_capacity(components.count() + 1);
-        for component in path {
-            if component == "~" {
-                if let Some(home_dir) = dirs::home_dir() {
-                    cache_dir.push(home_dir)
-                } else {
-                    return Err(Cow::Owned(format!(
-                        "Failed to expand home dir in PEXRC_ROOT={pexrc_root:?}"
-                    )));
-                }
-            } else {
-                cache_dir.push(component)
-            }
+fn is_home_dir(component: Component) -> bool {
+    matches!(component, Component::Normal(name) if name == "~")
+}
+
+fn expand_home_dir(path: PathBuf) -> Result<PathBuf, Cow<'static, str>> {
+    let mut expand = false;
+    let mut count = 0;
+    for component in path.components() {
+        count += 1;
+        if !expand && is_home_dir(component) {
+            expand = true;
         }
-        Ok(cache_dir.iter().collect())
+    }
+    if !expand {
+        return Ok(path);
+    }
+    let home_dir = dirs::home_dir().ok_or_else(|| {
+        Cow::Owned(format!(
+            "Failed to expand home dir in {path}",
+            path = path.display()
+        ))
+    })?;
+    let mut expanded_path = PathBuf::with_capacity(count);
+    for component in path.components() {
+        if is_home_dir(component) {
+            expanded_path.push(&home_dir)
+        } else {
+            expanded_path.push(component)
+        }
+    }
+    Ok(expanded_path.iter().collect())
+}
+
+pub enum CacheRoot {
+    Dir(PathBuf),
+    TempDir(TempDir),
+}
+
+impl Deref for CacheRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            CacheRoot::Dir(root) => root,
+            CacheRoot::TempDir(root) => root.path(),
+        }
+    }
+}
+
+impl AsRef<Path> for CacheRoot {
+    fn as_ref(&self) -> &Path {
+        self.deref()
+    }
+}
+
+fn ensure_writeable(path: PathBuf) -> Result<CacheRoot, Cow<'static, str>> {
+    for ancestor in path.ancestors() {
+        if !ancestor.exists() {
+            continue;
+        }
+        if tempfile::tempfile_in(ancestor).is_ok() {
+            return Ok(CacheRoot::Dir(path));
+        }
+    }
+    tempfile::tempdir()
+        .inspect(|temp_dir| {
+            warn!(
+                "The pexrc cache root of {path} is not writeable\n\
+                Falling back to a temporary cache root of {fallback} which will hurt \
+                performance.",
+                path = path.display(),
+                fallback = temp_dir.path().display()
+            )
+        })
+        .map(CacheRoot::TempDir)
+        .map_err(|err| {
+            Cow::Owned(format!(
+                "The pexrc cache root of {path} is not writeable and a temporary cache dir \
+                could not be established: {err}",
+                path = path.display()
+            ))
+        })
+}
+
+static PEXRC_ROOT: LazyLock<Result<CacheRoot, Cow<'static, str>>> = LazyLock::new(|| {
+    if let Some(pexrc_root) = env::var_os("PEXRC_ROOT") {
+        expand_home_dir(pexrc_root.into())
+    } else if let Some(pex_root) = env::var_os("PEX_ROOT") {
+        expand_home_dir(pex_root.into()).map(|pex_root| pex_root.join("rc").join("cache"))
     } else if let Some(cache_dir) = cache_dir("pexrc", ".pexrc") {
         Ok(cache_dir)
     } else {
@@ -61,7 +135,25 @@ static PEXRC_ROOT: LazyLock<Result<PathBuf, Cow<'static, str>>> = LazyLock::new(
             dir could not be determined and the user's home directory could not be determined.",
         ))
     }
+    .and_then(ensure_writeable)
 });
+
+#[dtor(unsafe)]
+fn cleanup_tmp_cache_root() {
+    if let Some(Ok(CacheRoot::TempDir(temp_dir))) = LazyLock::get(&PEXRC_ROOT) {
+        if let Err(err) = fs::remove_dir_all(temp_dir.path()) {
+            warn!(
+                "Leaked temp pexrc cache root {dir}: {err}",
+                dir = temp_dir.path().display()
+            )
+        } else {
+            debug!(
+                "Removed temp pexrc cache root: {dir}",
+                dir = temp_dir.path().display()
+            )
+        }
+    }
+}
 
 pub enum CacheDir {
     Interpreter,
@@ -70,8 +162,8 @@ pub enum CacheDir {
 }
 
 impl CacheDir {
-    pub fn root() -> anyhow::Result<&'static Path> {
-        PEXRC_ROOT.as_deref().map_err(|err| anyhow!("{err}"))
+    pub fn root() -> anyhow::Result<&'static CacheRoot> {
+        PEXRC_ROOT.as_ref().map_err(|err| anyhow!("{err}"))
     }
 
     fn version(&self) -> &'static str {
@@ -95,10 +187,16 @@ impl CacheDir {
     }
 }
 
-pub fn read_lock() -> Result<std::fs::File, Cow<'static, str>> {
-    let root = PEXRC_ROOT.as_deref().map_err(|err| err.clone())?;
-    std::fs::create_dir_all(root).map_err(|_| Cow::Borrowed("Failed to create PEXRC_ROOT dir."))?;
-    let lock = std::fs::File::create(root.join(".lck"))
+pub fn read_lock() -> Result<fs::File, Cow<'static, str>> {
+    let root = match PEXRC_ROOT.as_ref().map_err(|err| err.clone())? {
+        CacheRoot::Dir(root) => {
+            fs::create_dir_all(root)
+                .map_err(|_| Cow::Borrowed("Failed to create PEXRC_ROOT dir."))?;
+            root
+        }
+        CacheRoot::TempDir(root) => root.path(),
+    };
+    let lock = fs::File::create(root.join(".lck"))
         .map_err(|_| Cow::Borrowed("Failed to open PEXRC_ROOT read lock."))?;
     lock.lock_shared()
         .map_err(|_| Cow::Borrowed("Failed to obtain PEXRC_ROOT read lock."))?;

--- a/crates/pexrs/src/lib.rs
+++ b/crates/pexrs/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::{env, mem};
 
 use anyhow::{anyhow, bail};
-use cache::{CacheDir, HashOptions, Key, atomic_dir};
+use cache::{CacheDir, CacheRoot, HashOptions, Key, atomic_dir};
 use fs_err as fs;
 use interpreter::SearchPath;
 use itertools::Itertools;
@@ -89,10 +89,6 @@ pub fn boot(
     pex: impl AsRef<Path>,
     argv: Vec<String>,
 ) -> anyhow::Result<i32> {
-    let lock = match cache::read_lock() {
-        Ok(lock) => lock,
-        Err(err) => bail!("Failed to obtain PEXRC cache read lock: {err}"),
-    };
     #[cfg(feature = "tools")]
     if let Ok(tools) = env::var("PEX_TOOLS")
         && tools == "1"
@@ -103,13 +99,23 @@ pub fn boot(
         }
         std::process::exit(0);
     }
+    logging::init_default()?;
+    let lock = match cache::read_lock() {
+        Ok(lock) => lock,
+        Err(err) => bail!("Failed to obtain PEXRC cache read lock: {err}"),
+    };
     let mut command = prepare_boot(python, python_args, pex, argv)?;
     info!(
         "Booting with {exe} {args}",
         exe = command.get_program().to_string_lossy(),
         args = command.get_args().map(OsStr::to_string_lossy).join(" ")
     );
-    Ok(platform::exec(&mut command, &[lock])?)
+    if let Ok(CacheRoot::TempDir(temp_dir)) = CacheDir::root() {
+        command.env("PEXRC_ROOT", temp_dir.path());
+        Ok(platform::spawn(&mut command)?)
+    } else {
+        Ok(platform::exec(&mut command, &[lock])?)
+    }
 }
 
 fn prepare_boot(
@@ -118,7 +124,6 @@ fn prepare_boot(
     pex: impl AsRef<Path>,
     argv: Vec<String>,
 ) -> anyhow::Result<Command> {
-    logging::init_default()?;
     let venv = prepare_venv(
         python,
         pex.as_ref(),
@@ -134,6 +139,7 @@ fn prepare_boot(
 }
 
 pub fn mount(python: impl AsRef<Path>, pex: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+    logging::init_default()?;
     match cache::read_lock() {
         Ok(lock) => {
             // N.B.: We're being called from a Python program that lives longer than us via an
@@ -144,8 +150,6 @@ pub fn mount(python: impl AsRef<Path>, pex: impl AsRef<Path>) -> anyhow::Result<
         }
         Err(err) => bail!("Failed to obtain PEXRC cache read lock: {err}"),
     };
-
-    logging::init_default()?;
     prepare_venv(
         python,
         pex.as_ref(),

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -15,6 +15,7 @@ mod windows;
 
 use std::ffi::OsStr;
 use std::path::Path;
+use std::process::Command;
 use std::{fs, io};
 
 pub enum Perms {
@@ -72,4 +73,13 @@ pub fn link_or_copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<
                 ),
             )
         })
+}
+
+pub fn spawn(command: &mut Command) -> io::Result<i32> {
+    let mut child = command.spawn()?;
+    child.wait().map(|exit_status| {
+        exit_status
+            .code()
+            .unwrap_or_else(|| if exit_status.success() { 0 } else { 1 })
+    })
 }

--- a/crates/platform/src/windows.rs
+++ b/crates/platform/src/windows.rs
@@ -35,10 +35,5 @@ pub fn path_as_bytes(path: &Path) -> io::Result<&[u8]> {
 }
 
 pub fn exec(command: &mut Command, _files_to_keep_open: &[File]) -> io::Result<i32> {
-    let mut child = command.spawn()?;
-    child.wait().map(|exit_status| {
-        exit_status
-            .code()
-            .unwrap_or_else(|| if exit_status.success() { 0 } else { 1 })
-    })
+    crate::spawn(command)
 }


### PR DESCRIPTION
Also ensure the selected pexrc cache root is writable or fall back to
a tmp dir.