### PR TITLE
Fix bugs in the `repository` `PEX_TOOLS`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.11.1
+
+This release fixes bugs in the `repository {info,extract}` `PEX_TOOLS`.
+
 ## 0.11.0
 
 This release adds support for PEX-INFO `overridden` and `excluded` dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anstream",
  "anyhow",
@@ -3289,6 +3289,7 @@ dependencies = [
  "pep440_rs",
  "pep508_rs",
  "pex",
+ "platform",
  "rayon",
  "regex",
  "scripts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.11.0"
+version = "0.11.1"
 edition = { workspace = true }
 publish = false
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -30,6 +30,7 @@ owo-colors = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 pex = { path = "../pex" }
+platform = { path = "../platform" }
 rayon = { workspace = true }
 regex = { workspace = true }
 scripts = { path = "../scripts" }

--- a/crates/tools/src/commands/repository/extract.rs
+++ b/crates/tools/src/commands/repository/extract.rs
@@ -328,7 +328,7 @@ fn add_file(
     content: Cow<'_, str>,
 ) -> anyhow::Result<()> {
     let size = u64::try_from(content.as_ref().len())?;
-    let header = create_header(top_dir.join(path), size, timestamp)?;
+    let header = create_header(top_dir.join(path), size, false, timestamp)?;
     tar.append(&header, Cursor::new(content.as_ref()))?;
     Ok(())
 }
@@ -336,12 +336,13 @@ fn add_file(
 fn create_header(
     path: impl AsRef<Path>,
     size: u64,
+    is_executable: bool,
     timestamp: Option<DateTime<Utc>>,
 ) -> anyhow::Result<Header> {
     let mut header = tar::Header::new_ustar();
     header.set_path(path.as_ref())?;
     header.set_size(size);
-    header.set_mode(0o644);
+    header.set_mode(if is_executable { 0o755 } else { 0o644 });
     if let Some(timestamp) = timestamp {
         header.set_mtime(u64::try_from(timestamp.timestamp())?)
     }
@@ -460,6 +461,7 @@ fn add_loose_source(
                 }
             }
             sources.packages.insert(package);
+            continue;
         }
         let dst = src_dir.join(
             entry
@@ -469,7 +471,8 @@ fn add_loose_source(
         );
         if timestamp.is_some() {
             let size = entry.metadata()?.len();
-            let header = create_header(dst, size, timestamp)?;
+            let is_executable = platform::is_executable(entry.path())?;
+            let header = create_header(dst, size, is_executable, timestamp)?;
             tar.append(&header, File::open(entry.path())?)?
         } else {
             tar.append_path_with_name(entry.path(), dst)?

--- a/crates/tools/src/commands/repository/info.rs
+++ b/crates/tools/src/commands/repository/info.rs
@@ -42,7 +42,7 @@ pub(crate) fn display(python: &Path, pex: Pex, args: InfoArgs) -> anyhow::Result
                     "version": wheel_info.version,
                     "requires_python": wheel_info.requires_python,
                     "requires_dists": wheel_info.requires_dists,
-                    "location": pex.path.join(wheel_info.file_name)
+                    "location": pex.path.join(".deps").join(wheel_info.file_name)
                 }),
                 args.indent,
             )?;


### PR DESCRIPTION
These were found in Pex tests when integrating `pexrc` over there.