### PR TITLE
Fix two more PEX_TOOLS disparities.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 0.12.2
+
+This release fixes the `venv` PEX tool from trampling Pip provided by PEX deps when `--pip` is
+specified. At parity with Pex, a warning is issued if `--collisions-ok`; otherwise the tool exits
+with an error message explaining the conflict and the remedies.
+
+Additionally, the `repository extract` tool is changed to wait forever when `--serve`ing instead
+of timing out at 5 seconds if the server fails to come up. This is, again, at parity with Pex. In
+this case however, a `--timeout` option is added to control this.
+
 ## 0.12.1
 
 This release fixes the `venv` PEX tool `--pip` option for Python 2.7.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.12.1"
+version = "0.12.2"
 edition = { workspace = true }
 publish = false
 

--- a/crates/tools/src/commands/repository/extract.rs
+++ b/crates/tools/src/commands/repository/extract.rs
@@ -67,6 +67,12 @@ runs."
     /// The path of a file to write the `<pid>:<port>` of the find links server to.
     #[arg(long)]
     pid_file: Option<PathBuf>,
+
+    /// The maximum time to wait in (fractional) seconds for the server to start accepting
+    /// connections. If this timeout is reached, the command will exit with an error instead of
+    /// waiting indefinitely. The wait is indefinite by default.
+    #[arg(long, default_value_t = 0.0)]
+    timeout: f32,
 }
 
 pub(crate) fn extract(python: &Path, pex: Pex, args: ExtractArgs) -> anyhow::Result<()> {
@@ -107,6 +113,7 @@ pub(crate) fn extract(python: &Path, pex: Pex, args: ExtractArgs) -> anyhow::Res
                 &args.dest_dir,
                 args.port,
                 args.pid_file.as_deref(),
+                args.timeout,
             )?;
         }
     }
@@ -479,6 +486,7 @@ fn serve(
     root_dir: &Path,
     port: Option<u16>,
     pid_file: Option<&Path>,
+    timeout: f32,
 ) -> anyhow::Result<()> {
     let module = if interpreter.raw().version.major == 3 {
         "http.server"
@@ -527,7 +535,11 @@ fn serve(
         }
         Ok::<_, anyhow::Error>(())
     });
-    let port = recv.recv_timeout(Duration::from_secs(5))??;
+    let port = if timeout > 0.0 {
+        recv.recv_timeout(Duration::from_secs_f32(timeout))?
+    } else {
+        recv.recv()?
+    }?;
     eprintln!(
         "Serving find-links repo of {pex} via {find_links} at http://localhost:{port}",
         pex = pex_path.display(),

--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -6,6 +6,7 @@ use std::ffi::OsStr;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
@@ -15,7 +16,8 @@ use clap::{Args, ValueEnum};
 use fs_err as fs;
 use interpreter::SearchPath;
 use log::warn;
-use pex::{Layout, Pex, PexPath};
+use pep508_rs::PackageName;
+use pex::{CollectWheelMetadata, Layout, Pex, PexPath};
 use shell_quote::Quote;
 use venv::virtualenv::FileSystemLinker;
 use venv::{Provenance, Virtualenv, venv_pex};
@@ -226,7 +228,53 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
     let search_path = SearchPath::from_env()?;
     let pex_path = PexPath::from_pex_info(&pex.info, true);
     let additional_pexes = pex_path.load_pexes()?;
-    let resolve = pex.resolve(Some(python), additional_pexes.iter(), search_path, None)?;
+
+    let resolved_wheel_metadata = if args.pip {
+        Some(CollectWheelMetadata::new())
+    } else {
+        None
+    };
+    let resolve = pex.resolve(
+        Some(python),
+        additional_pexes.iter(),
+        search_path,
+        resolved_wheel_metadata.clone(),
+    )?;
+    let pip = if let Some(resolved_wheel_metadata) = resolved_wheel_metadata {
+        let pip = PackageName::from_str("pip")?;
+        if let Some(pip_wheel) = resolved_wheel_metadata
+            .into_collected()?
+            .iter()
+            .filter_map(|metadata| {
+                if metadata.project_name == pip {
+                    Some(metadata.file_name)
+                } else {
+                    None
+                }
+            })
+            .next()
+        {
+            let message = format_args!(
+                "You asked for --pip to be installed in the venv at {venv_dir},\n\
+                but the PEX at {pex} already contains {pip_wheel}",
+                venv_dir = args.venv_dir.display(),
+                pex = pex.path.display()
+            );
+            if args.collisions_ok {
+                warn!("{message}\nUsing {pip_wheel} from the PEX.");
+                false
+            } else {
+                bail!(
+                    "{message}\nConsider re-running either without --pip or with --collisions-ok."
+                )
+            }
+        } else {
+            true
+        }
+    } else {
+        false
+    };
+
     let mut scripts = pex.scripts()?;
 
     if args.force && args.venv_dir.exists() {
@@ -244,7 +292,7 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
             FileSystemLinker(),
             &mut scripts,
             args.system_site_packages,
-            args.pip,
+            pip,
             args.prompt.as_deref(),
         )?;
         venv.create_additional_pythons()?;


### PR DESCRIPTION
+ `venv --pip` now avoids trampling Pips in PEX deps like Pex, warning
  for `--collisions-ok` and erroring otherwise.
+ `repository extract --serve` now waits forever for server startup
  which can be controlled with a new `--timeout` option.