### PR TITLE
Fix `python-proxyw` application starting cursor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.13.1
+
+This release eliminates an erroneous application starting cursor that would persist for several
+seconds when a gui was launched via python-proxyw on Windows.
+
 ## 0.13.0
 
 This release brings support for `gui-scripts` and `pythonw.exe` on Windows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2241,6 +2241,7 @@ dependencies = [
  "pex",
  "platform",
  "target",
+ "windows",
  "zip",
 ]
 
@@ -3690,6 +3691,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,6 +3722,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3729,6 +3762,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3817,6 +3860,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.13.0"
+version = "0.13.1"
 edition = { workspace = true }
 publish = false
 

--- a/crates/build-system/src/downloads.rs
+++ b/crates/build-system/src/downloads.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io;
-use std::io::{ErrorKind, Read};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail};
@@ -58,16 +58,13 @@ impl<'a, D: Digest, R: Read> Read for DigestReader<'a, D, R> {
         self.amount_read +=
             u64::try_from(amount_read).expect("The pointer size will not be greater than 64 bits.");
         if self.amount_read > self.expected_size {
-            return Err(io::Error::new(
-                ErrorKind::FileTooLarge,
-                format!(
-                    "Read {total_read} bytes from {source} but it was expected to be \
+            return Err(io::Error::other(format!(
+                "Read {total_read} bytes from {source} but it was expected to be \
                     {expected_size} bytes.",
-                    total_read = self.amount_read,
-                    source = self.source,
-                    expected_size = self.expected_size
-                ),
-            ));
+                total_read = self.amount_read,
+                source = self.source,
+                expected_size = self.expected_size
+            )));
         }
         self.digest.update(&buffer[0..amount_read]);
         Ok(amount_read)

--- a/crates/python-proxy/Cargo.toml
+++ b/crates/python-proxy/Cargo.toml
@@ -23,5 +23,8 @@ platform = { path = "../platform" }
 target = { path = "../target" }
 zip = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = ["Win32_UI_WindowsAndMessaging"] }
+
 [features]
 windows = []

--- a/crates/python-proxy/src/bin/main.rs
+++ b/crates/python-proxy/src/bin/main.rs
@@ -3,7 +3,6 @@
 
 #![deny(clippy::all)]
 
-use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::process::exit;
 use std::{env, io};
@@ -14,12 +13,7 @@ use python_proxy::read_proxy;
 fn proxy_path() -> io::Result<PathBuf> {
     env::args()
         .next()
-        .ok_or_else(|| {
-            io::Error::new(
-                ErrorKind::NotFound,
-                "No argv0 was present; python-proxy cannot run.",
-            )
-        })
+        .ok_or_else(|| io::Error::other("No argv0 was present; python-proxy cannot run."))
         .map(PathBuf::from)
 }
 

--- a/crates/python-proxy/src/bin/mainw.rs
+++ b/crates/python-proxy/src/bin/mainw.rs
@@ -6,50 +6,108 @@
 #![windows_subsystem = "windows"]
 
 use std::env;
+use std::ffi::CString;
+use std::fmt::Display;
 use std::os::windows::process::CommandExt;
 use std::process::{Child, exit};
 
-use python_proxy::{PythonProxy, read_proxy};
+use anyhow::bail;
+use python_proxy::read_proxy;
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExA,
+    DestroyWindow,
+    HWND_MESSAGE,
+    MB_OK,
+    MSG,
+    MessageBoxA,
+    PM_REMOVE,
+    PeekMessageA,
+    WINDOW_EX_STYLE,
+    WINDOW_STYLE,
+};
+use windows::core::{PCSTR, s};
 
-// See: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
-const DETACHED_PROCESS: u32 = 0x00000008;
+#[macro_export]
+macro_rules! error {
+    ($($tt:tt)*) => {{
+        $crate::error_and_exit(format_args!($($tt)*));
+    }}
+}
+
+fn error_and_exit(message: impl Display) -> ! {
+    let message = unsafe { CString::new(message.to_string()).unwrap_unchecked() };
+    let message = PCSTR::from_raw(message.as_ptr() as *const _);
+    unsafe {
+        MessageBoxA(
+            None,        // hWnd (No owner window - this is a free-floating error dialog)
+            message,     // lpText
+            s!("Error"), // lpCaption
+            MB_OK,       // uType (Just an Ok button to dismiss the error dialog)
+        )
+    };
+    exit(1)
+}
+
+fn clear_app_starting_cursor_state() {
+    let mut msg = MSG::default();
+    unsafe {
+        // Create a message-only (invisible) window.
+        // See: https://learn.microsoft.com/en-us/windows/win32/winmsg/window-features#message-only-windows
+        if let Ok(hwnd) = CreateWindowExA(
+            WINDOW_EX_STYLE(0), // dwExStyle
+            // (See https://learn.microsoft.com/en-us/windows/win32/winmsg/about-window-classes#system-classes
+            // for the Static system window class)
+            s!("STATIC"),              // lpClassName
+            s!("pexrc python-proxyw"), // lpWindowName
+            WINDOW_STYLE(0),           // dwStyle
+            0,                         // X
+            0,                         // Y
+            0,                         // nWidth
+            0,                         // nHeight
+            Some(HWND_MESSAGE),        // hWndParent (This is what makes the window message-only)
+            None,                      // hMenu
+            None,                      // hInstance
+            None,                      // lpParam
+        ) {
+            // Process all pending messages (remove them from the window message queue); this is
+            // enough to clear the app starting cursor state.
+            // See: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagea
+            let _ = PeekMessageA(&mut msg, Some(hwnd), 0, 0, PM_REMOVE);
+            let _ = DestroyWindow(hwnd);
+        }
+    }
+}
 
 fn main() {
     let python_proxy = match env::current_exe().and_then(read_proxy) {
         Ok(python) => python,
-        Err(err) => {
-            eprintln!("Failed to determine python executable path: {err}");
-            exit(1);
-        }
+        Err(err) => error!("Failed to determine python executable path: {err}"),
     };
-
     let (mut command, _pexrc_cache_read_lock) = match python_proxy.prepare_command() {
         Ok(proxy) => proxy,
-        Err(err) => {
-            eprintln!("Failed to prepare python proxy command: {err}");
-            exit(1);
-        }
+        Err(err) => error!("Failed to prepare python proxy command: {err}"),
     };
-    command.creation_flags(DETACHED_PROCESS);
-
     match command.spawn() {
-        Ok(mut child) => match child.wait() {
-            Ok(exit_status) => {
-                if !exit_status.success() {
-                    exit(exit_status.code().unwrap_or(1))
+        Ok(mut child) => {
+            // Now that we've launched the child asynchronously, perform invisible windowed
+            // application activity to indicate we've started.
+            clear_app_starting_cursor_state();
+            match child.wait() {
+                Ok(exit_status) => {
+                    if !exit_status.success() {
+                        exit(exit_status.code().unwrap_or(1))
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        "Failed to wait for python proxy child process {id} to complete: {err}",
+                        id = child.id()
+                    )
                 }
             }
-            Err(err) => {
-                eprintln!(
-                    "Failed to wait for python proxy child process {id} to complete: {err}",
-                    id = child.id()
-                );
-                exit(1)
-            }
-        },
+        }
         Err(err) => {
-            eprintln!("{err}");
-            exit(1)
+            error!("Failed to spawn python proxy child process: {err}");
         }
     }
 }

--- a/python/tests/test_issue_103.py
+++ b/python/tests/test_issue_103.py
@@ -7,7 +7,7 @@ import os.path
 import subprocess
 
 import pytest
-from testing import IS_MAC, IS_WINDOWS
+from testing import IS_WINDOWS
 from testing.compare import compare
 
 TYPE_CHECKING = False


### PR DESCRIPTION
Set up and tear down a hidden window message pump to let Windows know
we're alive even though we only are around to launch another gui app.