### PR TITLE
Improve `uvrc test` CLI ergonomics with `--release`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             export UV_PYTHON="cpython-$(cat .python-version)-windows-aarch64"
           fi
           cargo --color always test --all
-          PEXRC_PROFILE=release uv run dev-cmd --color always test -- -vvs
+          uv run dev-cmd --color always test -- --release -vvs
 
   final-status:
     name: Gather Final Status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pexrc"
-version = "0.1.0"
 requires-python = ">=2.7"
+dynamic = ["version"]
 
 [tool.uv]
 package = false

--- a/python/testing/bin/run-tests.py
+++ b/python/testing/bin/run-tests.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+from argparse import ArgumentParser, RawTextHelpFormatter
 
 PYTHONPATH = os.path.abspath("python")
 sys.path.append(PYTHONPATH)
@@ -18,13 +19,13 @@ from testing import IS_MAC  # noqa: E402
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     # Ruff doesn't understand Python 2 and thus the type comment usages.
-    from typing import Any  # noqa: F401
+    from typing import Any, List, Optional  # noqa: F401
 
 
-def ensure_pexrc():
-    # type: () -> str
+def ensure_pexrc(release_mode):
+    # type: (Optional[bool]) -> str
 
-    profile = os.environ.pop("PEXRC_PROFILE", "dev")
+    profile = "release" if release_mode else os.environ.pop("PEXRC_PROFILE", "dev")
     env = os.environ.copy()
     env.update(PEXRC_CLIB_FEATURES="tools")
     subprocess.check_call(args=["cargo", "build", "--profile", profile], env=env)
@@ -58,7 +59,39 @@ def seed_pexrc_root(
 def run_tests():
     # type: () -> Any
 
-    pexrc = ensure_pexrc()
+    arg_parser = ArgumentParser(
+        description=(
+            "Runs pexrc integration tests using pytest.\n"
+            "\n"
+            "Any options not documented below are passed through to pytest.\n"
+            "To explicitly pass options to pytest, separate them with an additional `--`; i.e.:\n"
+            "+ `uv run dev-cmd test -- -h` will display this help.\n"
+            "+ `uv run dev-cmd test -- -- -h` will display pytest help"
+        ),
+        formatter_class=RawTextHelpFormatter,
+    )
+    arg_parser.add_argument(
+        "--release",
+        default=None,
+        action="store_true",
+        help="Build pexrc for use in tests in release mode.",
+    )
+
+    run_test_args = []
+    explicit_pytest_args = None  # type: Optional[List[str]]
+    for arg in sys.argv[1:]:
+        if explicit_pytest_args is None:
+            if arg == "--":
+                explicit_pytest_args = []
+            else:
+                run_test_args.append(arg)
+        else:
+            explicit_pytest_args.append(arg)
+    options, pytest_args = arg_parser.parse_known_args(run_test_args)
+    if explicit_pytest_args:
+        pytest_args.extend(explicit_pytest_args)
+
+    pexrc = ensure_pexrc(options.release)
     env = os.environ.copy()
     session_dir = tempfile.mkdtemp(prefix="pexrc-pytest.", suffix=".session")
     atexit.register(shutil.rmtree, session_dir)
@@ -69,7 +102,7 @@ def run_tests():
         PYTHONPATH=PYTHONPATH,
     )
     return subprocess.call(
-        args=["pytest", "-n", "auto"] + sys.argv[1:],
+        args=["pytest", "-n", "auto"] + pytest_args,
         cwd=os.path.abspath(os.path.join("python", "tests")),
         env=env,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1214,7 +1214,6 @@ wheels = [
 
 [[package]]
 name = "pexrc"
-version = "0.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is less clunky than `PEXRC_PROFILE=release` (which still works) and
is self documenting.