### PR TITLE
Encapsulate `pexrc` CLI a bit better.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "bstr",
  "build-system",
  "cache",
+ "chrono",
  "clap",
  "clap-verbosity-flag",
  "cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ anstream = { workspace = true }
 anyhow = { workspace = true }
 boot = { path = "crates/boot" }
 cache = { path = "crates/cache" }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap-verbosity-flag = { workspace = true }
 cli = { path = "crates/cli" }

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -6,9 +6,9 @@
 use clap::{Args, Parser, Subcommand};
 use pexrc::commands::build::Build;
 use pexrc::commands::extract::Extract;
+use pexrc::commands::info;
 use pexrc::commands::inject::Inject;
 use pexrc::commands::script::Script;
-use pexrc::commands::info;
 
 /// Pex Runtime Control.
 #[derive(Parser)]

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -4,11 +4,11 @@
 #![deny(clippy::all)]
 
 use clap::{Args, Parser, Subcommand};
-use pexrc::commands::build::BuildArgs;
-use pexrc::commands::extract::ExtractArgs;
-use pexrc::commands::inject::InjectArgs;
-use pexrc::commands::script::ScriptArgs;
-use pexrc::commands::{build, extract, info, inject, script};
+use pexrc::commands::build::Build;
+use pexrc::commands::extract::Extract;
+use pexrc::commands::inject::Inject;
+use pexrc::commands::script::Script;
+use pexrc::commands::info;
 
 /// Pex Runtime Control.
 #[derive(Parser)]
@@ -32,7 +32,7 @@ enum Commands {
         jobs: Jobs,
 
         #[command(flatten)]
-        build_args: BuildArgs,
+        build: Build,
     },
     /// Extract PEX dependencies as wheels.
     Extract {
@@ -40,7 +40,7 @@ enum Commands {
         jobs: Jobs,
 
         #[command(flatten)]
-        extract_args: ExtractArgs,
+        extract: Extract,
     },
     /// Inject traditional PEXes with native runtimes.
     Inject {
@@ -48,12 +48,12 @@ enum Commands {
         jobs: Jobs,
 
         #[command(flatten)]
-        inject_args: InjectArgs,
+        inject: Inject,
     },
     /// Provide information about the supported target runtimes.
     Info,
     /// Create a Windows-style Python venv console script executable.
-    Script(ScriptArgs),
+    Script(Script),
 }
 
 #[derive(Args)]
@@ -80,19 +80,19 @@ fn main() -> anyhow::Result<()> {
     cli.color.write_global();
 
     match cli.command {
-        Commands::Build { jobs, build_args } => {
+        Commands::Build { jobs, build } => {
             jobs.configure()?;
-            build::create_pex(build_args)
+            build.execute()
         }
-        Commands::Extract { jobs, extract_args } => {
+        Commands::Extract { jobs, extract } => {
             jobs.configure()?;
-            extract::to_dir(extract_args)
+            extract.execute()
         }
-        Commands::Inject { jobs, inject_args } => {
+        Commands::Inject { jobs, inject } => {
             jobs.configure()?;
-            inject::inject_all(inject_args)
+            inject.execute()
         }
         Commands::Info => info::display(),
-        Commands::Script(script_args) => script::create(script_args),
+        Commands::Script(script) => script.execute(),
     }
 }

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -3,18 +3,12 @@
 
 #![deny(clippy::all)]
 
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::sync::LazyLock;
-
-use clap::builder::PossibleValue;
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
-use indexmap::{Equivalent, IndexSet};
-use pex::{Pex, WheelOptions};
-use pexrc::commands::{extract, info, inject, script};
-use pexrc::embeds::{CLIB_BY_TARGET, PROXY_BY_TARGET, PROXYW_BY_TARGET};
-use pexrc::source;
-use target::Target;
+use clap::{Args, Parser, Subcommand};
+use pexrc::commands::build::BuildArgs;
+use pexrc::commands::extract::ExtractArgs;
+use pexrc::commands::inject::InjectArgs;
+use pexrc::commands::script::ScriptArgs;
+use pexrc::commands::{build, extract, info, inject, script};
 
 /// Pex Runtime Control.
 #[derive(Parser)]
@@ -30,135 +24,54 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(Clone, ValueEnum)]
-enum CompressionMethod {
-    Deflated,
-    Zstd,
-}
-
-impl From<CompressionMethod> for zip::CompressionMethod {
-    fn from(val: CompressionMethod) -> Self {
-        match val {
-            CompressionMethod::Deflated => zip::CompressionMethod::Deflated,
-            CompressionMethod::Zstd => zip::CompressionMethod::Zstd,
-        }
-    }
-}
-
-#[derive(Clone, Hash, Eq, PartialEq)]
-struct SimplifiedTarget(target::SimplifiedTarget);
-
-impl Display for SimplifiedTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        f.write_str(self.0.as_str())
-    }
-}
-
-impl Equivalent<target::SimplifiedTarget> for SimplifiedTarget {
-    fn equivalent(&self, key: &target::SimplifiedTarget) -> bool {
-        &self.0 == key
-    }
-}
-
-static AVAILABLE_TARGETS: LazyLock<Vec<SimplifiedTarget>> = LazyLock::new(|| {
-    CLIB_BY_TARGET
-        .keys()
-        .chain(PROXY_BY_TARGET.keys())
-        .collect::<IndexSet<_>>()
-        .into_iter()
-        .map(|target| SimplifiedTarget(*target))
-        .collect()
-});
-
-impl ValueEnum for SimplifiedTarget {
-    fn value_variants<'a>() -> &'a [Self] {
-        AVAILABLE_TARGETS.as_slice()
-    }
-
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(PossibleValue::new(self.0.as_str()))
-    }
-}
-
-impl From<SimplifiedTarget> for target::SimplifiedTarget {
-    fn from(value: SimplifiedTarget) -> Self {
-        value.0
-    }
-}
-
 #[derive(Subcommand)]
 enum Commands {
+    /// Build a PEX from source files and requirements.
+    Build {
+        #[command(flatten)]
+        jobs: Jobs,
+
+        #[command(flatten)]
+        build_args: BuildArgs,
+    },
     /// Extract PEX dependencies as wheels.
     Extract {
-        /// The maximum number of parallel jobs to use when extracting wheels.
-        #[arg(short = 'j', long)]
-        jobs: Option<usize>,
+        #[command(flatten)]
+        jobs: Jobs,
 
-        #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
-        compression_method: CompressionMethod,
-
-        #[arg(long)]
-        compression_level: Option<i64>,
-
-        /// The directory to extract the wheels to.
-        #[arg(short = 'd', long)]
-        dest_dir: PathBuf,
-
-        /// The PEX to extract dependency wheels from. Can be a path or URL.
-        #[arg(value_name = "PEX")]
-        pex: String,
+        #[command(flatten)]
+        extract_args: ExtractArgs,
     },
     /// Inject traditional PEXes with native runtimes.
     Inject {
-        /// The maximum number of parallel jobs to use when injecting PEXes.
-        #[arg(short = 'j', long)]
-        jobs: Option<usize>,
+        #[command(flatten)]
+        jobs: Jobs,
 
-        #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
-        compression_method: CompressionMethod,
-
-        #[arg(long)]
-        compression_level: Option<i64>,
-
-        #[arg(long = "target")]
-        #[arg(action=ArgAction::Append)]
-        targets: Vec<SimplifiedTarget>,
-
-        #[arg(short = 'p', long)]
-        preferred_python: Option<PathBuf>,
-
-        /// The PEXes to inject with a native runtime. Can be paths or URLs.
-        #[arg(value_name = "PEX", required = true)]
-        pexes: Vec<String>,
+        #[command(flatten)]
+        inject_args: InjectArgs,
     },
     /// Provide information about the supported target runtimes.
     Info,
     /// Create a Windows-style Python venv console script executable.
-    Script {
-        #[arg(long)]
-        target: Option<SimplifiedTarget>,
-
-        #[arg(short = 'p', long)]
-        python: PathBuf,
-
-        #[arg(short = 'o', long)]
-        output_file: PathBuf,
-
-        #[arg(long, default_value_t = false)]
-        gui: bool,
-
-        #[arg(value_name = "SCRIPT")]
-        script: PathBuf,
-    },
+    Script(ScriptArgs),
 }
 
-fn configure_jobs(jobs: Option<usize>) -> anyhow::Result<()> {
-    if let Some(jobs) = jobs {
-        rayon::ThreadPoolBuilder::default()
-            .num_threads(jobs)
-            .build_global()?;
+#[derive(Args)]
+struct Jobs {
+    /// The maximum number of parallel jobs to use.
+    #[arg(short = 'j', long)]
+    jobs: Option<usize>,
+}
+
+impl Jobs {
+    fn configure(&self) -> anyhow::Result<()> {
+        if let Some(jobs) = self.jobs {
+            rayon::ThreadPoolBuilder::default()
+                .num_threads(jobs)
+                .build_global()?;
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 fn main() -> anyhow::Result<()> {
@@ -167,95 +80,19 @@ fn main() -> anyhow::Result<()> {
     cli.color.write_global();
 
     match cli.command {
-        Commands::Extract {
-            jobs,
-            compression_method,
-            compression_level,
-            dest_dir,
-            pex,
-        } => {
-            configure_jobs(jobs)?;
-            let pex = source::to_path(pex, Some(&dest_dir))?;
-            extract::to_dir(
-                &dest_dir,
-                Pex::load(&pex)?,
-                &WheelOptions::new(compression_method.into(), compression_level, None),
-            )
+        Commands::Build { jobs, build_args } => {
+            jobs.configure()?;
+            build::create_pex(build_args)
         }
-        Commands::Inject {
-            jobs,
-            compression_method,
-            compression_level,
-            targets,
-            preferred_python,
-            pexes,
-        } => {
-            configure_jobs(jobs)?;
-            let (clibs, proxies) = if !targets.is_empty() {
-                (
-                    targets
-                        .iter()
-                        .map(|target| {
-                            CLIB_BY_TARGET.get(target).expect(
-                                "The allowed --target values are all keys in CLIB_BY_TARGET.",
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                    targets
-                        .iter()
-                        .map(|target| {
-                            PROXY_BY_TARGET.get(target).expect(
-                                "The allowed --target values are all keys in PROXY_BY_TARGET.",
-                            )
-                        })
-                        .chain(
-                            targets
-                                .iter()
-                                .filter_map(|target| PROXYW_BY_TARGET.get(target)),
-                        )
-                        .collect::<Vec<_>>(),
-                )
-            } else {
-                (
-                    CLIB_BY_TARGET.values().collect::<Vec<_>>(),
-                    PROXY_BY_TARGET
-                        .values()
-                        .chain(PROXYW_BY_TARGET.values())
-                        .collect::<Vec<_>>(),
-                )
-            };
-            let pexes = pexes
-                .into_iter()
-                .map(|source| source::to_path(source, None))
-                .collect::<anyhow::Result<Vec<_>>>()?;
-            inject::inject_all(
-                pexes,
-                &WheelOptions::new(compression_method.into(), compression_level, None),
-                clibs.as_slice(),
-                proxies.as_slice(),
-                preferred_python.as_deref(),
-            )
+        Commands::Extract { jobs, extract_args } => {
+            jobs.configure()?;
+            extract::to_dir(extract_args)
+        }
+        Commands::Inject { jobs, inject_args } => {
+            jobs.configure()?;
+            inject::inject_all(inject_args)
         }
         Commands::Info => info::display(),
-        Commands::Script {
-            target,
-            python,
-            script,
-            output_file,
-            gui: is_gui,
-        } => {
-            if let Some(target) = target {
-                script::create(target.into(), &python, &script, &output_file, is_gui)
-            } else {
-                let current_target = Target::current()?;
-                script::create(
-                    current_target.simplified_target_triple()?,
-                    &python,
-                    &script,
-                    &output_file,
-                    is_gui,
-                )
-            }
-        }
+        Commands::Script(script_args) => script::create(script_args),
     }
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+
+#[derive(Args)]
+pub struct BuildArgs {
+    /// Requirements to include in the PEX.
+    #[arg(value_name = "REQUIREMENT")]
+    requirements: Vec<String>,
+}
+
+pub fn create_pex(_build_args: BuildArgs) -> anyhow::Result<()> {
+    todo!("Creating a PEX from sources and requirements is coming soon.")
+}

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -4,12 +4,14 @@
 use clap::Args;
 
 #[derive(Args)]
-pub struct BuildArgs {
+pub struct Build {
     /// Requirements to include in the PEX.
     #[arg(value_name = "REQUIREMENT")]
     requirements: Vec<String>,
 }
 
-pub fn create_pex(_build_args: BuildArgs) -> anyhow::Result<()> {
-    todo!("Creating a PEX from sources and requirements is coming soon.")
+impl Build {
+    pub fn execute(self) -> anyhow::Result<()> {
+        todo!("Creating a PEX from sources and requirements is coming soon.")
+    }
 }

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -3,18 +3,18 @@
 
 use std::cmp;
 use std::io::BufReader;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use cache::Fingerprint;
 use clap::Args;
 use owo_colors::OwoColorize;
-use pex::Pex;
+use pex::{Pex, WheelOptions};
 
 use crate::compression_method::CompressionArgs;
 use crate::source;
 
 #[derive(Args)]
-pub struct ExtractArgs {
+pub struct Extract {
     #[command(flatten)]
     compression_args: CompressionArgs,
 
@@ -27,12 +27,17 @@ pub struct ExtractArgs {
     pex: String,
 }
 
-pub fn to_dir(extract_args: ExtractArgs) -> anyhow::Result<()> {
-    let pex = source::to_path(extract_args.pex, Some(&extract_args.dest_dir))?;
-    let pex = Pex::load(&pex)?;
-    let options = extract_args.compression_args.into_wheel_options(None);
+impl Extract {
+    pub fn execute(self) -> anyhow::Result<()> {
+        let pex = source::to_path(self.pex, Some(&self.dest_dir))?;
+        let pex = Pex::load(&pex)?;
+        let options = self.compression_args.into_wheel_options(None);
+        to_dir(&self.dest_dir, pex, &options)
+    }
+}
 
-    let wheels = pex::repackage_wheels(&pex, &options, &extract_args.dest_dir)?;
+fn to_dir(dest_dir: &Path, pex: Pex, options: &WheelOptions) -> anyhow::Result<()> {
+    let wheels = pex::repackage_wheels(&pex, options, dest_dir)?;
     let count = wheels.len();
 
     let mut wheel_info = Vec::with_capacity(count);

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -3,14 +3,36 @@
 
 use std::cmp;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::PathBuf;
 
 use cache::Fingerprint;
+use clap::Args;
 use owo_colors::OwoColorize;
-use pex::{Pex, WheelOptions};
+use pex::Pex;
 
-pub fn to_dir(dest_dir: &Path, pex: Pex, options: &WheelOptions) -> anyhow::Result<()> {
-    let wheels = pex::repackage_wheels(&pex, options, dest_dir)?;
+use crate::compression_method::CompressionArgs;
+use crate::source;
+
+#[derive(Args)]
+pub struct ExtractArgs {
+    #[command(flatten)]
+    compression_args: CompressionArgs,
+
+    /// The directory to extract the wheels to.
+    #[arg(short = 'd', long)]
+    dest_dir: PathBuf,
+
+    /// The PEX to extract dependency wheels from. Can be a path or URL.
+    #[arg(value_name = "PEX")]
+    pex: String,
+}
+
+pub fn to_dir(extract_args: ExtractArgs) -> anyhow::Result<()> {
+    let pex = source::to_path(extract_args.pex, Some(&extract_args.dest_dir))?;
+    let pex = Pex::load(&pex)?;
+    let options = extract_args.compression_args.into_wheel_options(None);
+
+    let wheels = pex::repackage_wheels(&pex, &options, &extract_args.dest_dir)?;
     let count = wheels.len();
 
     let mut wheel_info = Vec::with_capacity(count);

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, anyhow, bail};
 use boot::{inject_boot, sh_boot_shebang, write_boot};
 use cache::{DigestingReader, Fingerprint, default_digest};
+use clap::{ArgAction, Args};
 use enumset::EnumSet;
 use fs_err as fs;
 use fs_err::File;
@@ -27,17 +28,78 @@ use tempfile::NamedTempFile;
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-use crate::embeds::Binary;
+use crate::compression_method::CompressionArgs;
+use crate::embeds::{Binary, CLIB_BY_TARGET, PROXY_BY_TARGET, PROXYW_BY_TARGET};
+use crate::source;
 
-pub fn inject_all(
-    pexes: Vec<PathBuf>,
-    options: &WheelOptions,
-    clibs: &[&Binary],
-    proxies: &[&Binary],
-    preferred_python: Option<&Path>,
-) -> anyhow::Result<()> {
+#[derive(Args)]
+pub struct InjectArgs {
+    #[command(flatten)]
+    compression_args: CompressionArgs,
+
+    #[arg(long = "target")]
+    #[arg(action=ArgAction::Append)]
+    targets: Vec<crate::simplified_target::SimplifiedTarget>,
+
+    #[arg(short = 'p', long)]
+    preferred_python: Option<PathBuf>,
+
+    /// The PEXes to inject with a native runtime. Can be paths or URLs.
+    #[arg(value_name = "PEX", required = true)]
+    pexes: Vec<String>,
+}
+
+pub fn inject_all(inject_args: InjectArgs) -> anyhow::Result<()> {
+    let (clibs, proxies) = if !inject_args.targets.is_empty() {
+        (
+            inject_args
+                .targets
+                .iter()
+                .map(|target| {
+                    CLIB_BY_TARGET
+                        .get(target)
+                        .expect("The allowed --target values are all keys in CLIB_BY_TARGET.")
+                })
+                .collect::<Vec<_>>(),
+            inject_args
+                .targets
+                .iter()
+                .map(|target| {
+                    PROXY_BY_TARGET
+                        .get(target)
+                        .expect("The allowed --target values are all keys in PROXY_BY_TARGET.")
+                })
+                .chain(
+                    inject_args
+                        .targets
+                        .iter()
+                        .filter_map(|target| PROXYW_BY_TARGET.get(target)),
+                )
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        (
+            CLIB_BY_TARGET.values().collect::<Vec<_>>(),
+            PROXY_BY_TARGET
+                .values()
+                .chain(PROXYW_BY_TARGET.values())
+                .collect::<Vec<_>>(),
+        )
+    };
+    let pexes = inject_args
+        .pexes
+        .into_iter()
+        .map(|source| source::to_path(source, None))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let options = inject_args.compression_args.into_wheel_options(None);
     for pex in pexes {
-        inject(&pex, options, clibs, proxies, preferred_python)?
+        inject(
+            &pex,
+            &options,
+            clibs.as_slice(),
+            proxies.as_slice(),
+            inject_args.preferred_python.as_deref(),
+        )?
     }
     Ok(())
 }

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -33,7 +33,7 @@ use crate::embeds::{Binary, CLIB_BY_TARGET, PROXY_BY_TARGET, PROXYW_BY_TARGET};
 use crate::source;
 
 #[derive(Args)]
-pub struct InjectArgs {
+pub struct Inject {
     #[command(flatten)]
     compression_args: CompressionArgs,
 
@@ -49,57 +49,66 @@ pub struct InjectArgs {
     pexes: Vec<String>,
 }
 
-pub fn inject_all(inject_args: InjectArgs) -> anyhow::Result<()> {
-    let (clibs, proxies) = if !inject_args.targets.is_empty() {
-        (
-            inject_args
-                .targets
-                .iter()
-                .map(|target| {
-                    CLIB_BY_TARGET
-                        .get(target)
-                        .expect("The allowed --target values are all keys in CLIB_BY_TARGET.")
-                })
-                .collect::<Vec<_>>(),
-            inject_args
-                .targets
-                .iter()
-                .map(|target| {
-                    PROXY_BY_TARGET
-                        .get(target)
-                        .expect("The allowed --target values are all keys in PROXY_BY_TARGET.")
-                })
-                .chain(
-                    inject_args
-                        .targets
-                        .iter()
-                        .filter_map(|target| PROXYW_BY_TARGET.get(target)),
-                )
-                .collect::<Vec<_>>(),
-        )
-    } else {
-        (
-            CLIB_BY_TARGET.values().collect::<Vec<_>>(),
-            PROXY_BY_TARGET
-                .values()
-                .chain(PROXYW_BY_TARGET.values())
-                .collect::<Vec<_>>(),
-        )
-    };
-    let pexes = inject_args
-        .pexes
-        .into_iter()
-        .map(|source| source::to_path(source, None))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let options = inject_args.compression_args.into_wheel_options(None);
-    for pex in pexes {
-        inject(
-            &pex,
+impl Inject {
+    pub fn execute(self) -> anyhow::Result<()> {
+        let (clibs, proxies) = if !self.targets.is_empty() {
+            (
+                self.targets
+                    .iter()
+                    .map(|target| {
+                        CLIB_BY_TARGET
+                            .get(target)
+                            .expect("The allowed --target values are all keys in CLIB_BY_TARGET.")
+                    })
+                    .collect::<Vec<_>>(),
+                self.targets
+                    .iter()
+                    .map(|target| {
+                        PROXY_BY_TARGET
+                            .get(target)
+                            .expect("The allowed --target values are all keys in PROXY_BY_TARGET.")
+                    })
+                    .chain(
+                        self.targets
+                            .iter()
+                            .filter_map(|target| PROXYW_BY_TARGET.get(target)),
+                    )
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            (
+                CLIB_BY_TARGET.values().collect::<Vec<_>>(),
+                PROXY_BY_TARGET
+                    .values()
+                    .chain(PROXYW_BY_TARGET.values())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let pexes = self
+            .pexes
+            .into_iter()
+            .map(|source| source::to_path(source, None))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let options = self.compression_args.into_wheel_options(None);
+        inject_all(
+            pexes,
             &options,
             clibs.as_slice(),
             proxies.as_slice(),
-            inject_args.preferred_python.as_deref(),
-        )?
+            self.preferred_python.as_deref(),
+        )
+    }
+}
+
+fn inject_all(
+    pexes: Vec<PathBuf>,
+    options: &WheelOptions,
+    clibs: &[&Binary],
+    proxies: &[&Binary],
+    preferred_python: Option<&Path>,
+) -> anyhow::Result<()> {
+    for pex in pexes {
+        inject(&pex, options, clibs, proxies, preferred_python)?
     }
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod build;
 pub mod extract;
 pub mod info;
 pub mod inject;

--- a/src/commands/script.rs
+++ b/src/commands/script.rs
@@ -1,27 +1,48 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::path::PathBuf;
 
+use clap::Args;
 use fs_err as fs;
 use python_proxy::ProxySource;
-use target::SimplifiedTarget;
+use target::Target;
 
 use crate::embeds::read_proxy_content;
 
-pub fn create(
-    target: SimplifiedTarget,
-    python: &Path,
-    script: &Path,
-    output_file: &Path,
-    is_gui: bool,
-) -> anyhow::Result<()> {
+#[derive(Args)]
+pub struct ScriptArgs {
+    #[arg(long)]
+    target: Option<crate::simplified_target::SimplifiedTarget>,
+
+    #[arg(short = 'p', long)]
+    python: PathBuf,
+
+    #[arg(short = 'o', long)]
+    output_file: PathBuf,
+
+    #[arg(long, default_value_t = false)]
+    gui: bool,
+
+    #[arg(value_name = "SCRIPT")]
+    script: PathBuf,
+}
+
+pub fn create(script_args: ScriptArgs) -> anyhow::Result<()> {
+    let target = if let Some(target) = script_args.target {
+        target.into()
+    } else {
+        let current_target = Target::current()?;
+        current_target.simplified_target_triple()?
+    };
+
+    let is_gui = script_args.gui;
     let proxy_bytes = Box::new(read_proxy_content(target, is_gui)?);
-    let script = fs::read_to_string(script)?;
-    let target_script = fs::File::create(output_file)?;
+    let script = fs::read_to_string(script_args.script)?;
+    let target_script = fs::File::create(script_args.output_file)?;
     python_proxy::create(
         ProxySource::Read(proxy_bytes),
-        python,
+        &script_args.python,
         target_script.into_file(),
         Some(script),
         is_gui,

--- a/src/commands/script.rs
+++ b/src/commands/script.rs
@@ -1,17 +1,17 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use fs_err as fs;
 use python_proxy::ProxySource;
-use target::Target;
+use target::{SimplifiedTarget, Target};
 
 use crate::embeds::read_proxy_content;
 
 #[derive(Args)]
-pub struct ScriptArgs {
+pub struct Script {
     #[arg(long)]
     target: Option<crate::simplified_target::SimplifiedTarget>,
 
@@ -28,21 +28,37 @@ pub struct ScriptArgs {
     script: PathBuf,
 }
 
-pub fn create(script_args: ScriptArgs) -> anyhow::Result<()> {
-    let target = if let Some(target) = script_args.target {
-        target.into()
-    } else {
-        let current_target = Target::current()?;
-        current_target.simplified_target_triple()?
-    };
+impl Script {
+    pub fn execute(self) -> anyhow::Result<()> {
+        let target = if let Some(target) = self.target {
+            target.into()
+        } else {
+            let current_target = Target::current()?;
+            current_target.simplified_target_triple()?
+        };
+        create(
+            target,
+            &self.python,
+            &self.script,
+            &self.output_file,
+            self.gui,
+        )
+    }
+}
 
-    let is_gui = script_args.gui;
+pub fn create(
+    target: SimplifiedTarget,
+    python: &Path,
+    script: &Path,
+    output_file: &Path,
+    is_gui: bool,
+) -> anyhow::Result<()> {
     let proxy_bytes = Box::new(read_proxy_content(target, is_gui)?);
-    let script = fs::read_to_string(script_args.script)?;
-    let target_script = fs::File::create(script_args.output_file)?;
+    let script = fs::read_to_string(script)?;
+    let target_script = fs::File::create(output_file)?;
     python_proxy::create(
         ProxySource::Read(proxy_bytes),
-        &script_args.python,
+        python,
         target_script.into_file(),
         Some(script),
         is_gui,

--- a/src/compression_method.rs
+++ b/src/compression_method.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::{DateTime, Utc};
+use clap::{Args, ValueEnum};
+use pex::WheelOptions;
+
+#[derive(Clone, ValueEnum)]
+pub enum CompressionMethod {
+    Deflated,
+    Zstd,
+}
+
+impl From<CompressionMethod> for zip::CompressionMethod {
+    fn from(val: CompressionMethod) -> Self {
+        match val {
+            CompressionMethod::Deflated => zip::CompressionMethod::Deflated,
+            CompressionMethod::Zstd => zip::CompressionMethod::Zstd,
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct CompressionArgs {
+    #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
+    compression_method: CompressionMethod,
+
+    #[arg(long)]
+    compression_level: Option<i64>,
+}
+
+impl CompressionArgs {
+    pub fn into_wheel_options(self, timestamp: Option<DateTime<Utc>>) -> WheelOptions {
+        WheelOptions::new(
+            self.compression_method.into(),
+            self.compression_level,
+            timestamp,
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,7 @@
 #![deny(clippy::all)]
 
 pub mod commands;
+pub mod compression_method;
 pub mod embeds;
+pub mod simplified_target;
 pub mod source;

--- a/src/simplified_target.rs
+++ b/src/simplified_target.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+use std::sync::LazyLock;
+
+use clap::ValueEnum;
+use clap::builder::PossibleValue;
+use indexmap::{Equivalent, IndexSet};
+
+use crate::embeds::{CLIB_BY_TARGET, PROXY_BY_TARGET};
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct SimplifiedTarget(target::SimplifiedTarget);
+
+impl Display for SimplifiedTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.write_str(self.0.as_str())
+    }
+}
+
+impl Equivalent<target::SimplifiedTarget> for SimplifiedTarget {
+    fn equivalent(&self, key: &target::SimplifiedTarget) -> bool {
+        &self.0 == key
+    }
+}
+
+static AVAILABLE_TARGETS: LazyLock<Vec<SimplifiedTarget>> = LazyLock::new(|| {
+    CLIB_BY_TARGET
+        .keys()
+        .chain(PROXY_BY_TARGET.keys())
+        .collect::<IndexSet<_>>()
+        .into_iter()
+        .map(|target| SimplifiedTarget(*target))
+        .collect()
+});
+
+impl ValueEnum for SimplifiedTarget {
+    fn value_variants<'a>() -> &'a [Self] {
+        AVAILABLE_TARGETS.as_slice()
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.0.as_str()))
+    }
+}
+
+impl From<SimplifiedTarget> for target::SimplifiedTarget {
+    fn from(value: SimplifiedTarget) -> Self {
+        value.0
+    }
+}


### PR DESCRIPTION
Common options are now DRYed up and a build command is stubbed out that
will use some of these newly encapsulated options.