### PR TITLE
Fix `pexrc inject` target platform detection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.16.2
+
+This release fixes `pexrc inject` target platform detection to handle wheels with compressed tag
+sets.
+
 ## 0.16.1
 
 This release fixes interpreter detection for `pyenv` shims on unix. Previously the cache of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.16.1"
+version = "0.16.2"
 edition = { workspace = true }
 publish = false
 

--- a/python/tests/test_issue_135.py
+++ b/python/tests/test_issue_135.py
@@ -8,6 +8,7 @@ import subprocess
 
 import pytest
 from testing import IS_WINDOWS, IS_X86_64, pexrc_inject
+from testing.interpreter import ensure_python
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -29,4 +30,5 @@ def test_issue_135(tmpdir):
         args=["pex", "--platform", "win-amd64-cp-314-cp314", "pythonnet==3.1.0", "-o", pex]
     )
     injected_pex = pexrc_inject(pex)
-    subprocess.check_call(args=[injected_pex, "-c", "import pythonnet"])
+    python = ensure_python(version=(3, 14))
+    subprocess.check_call(args=[python, injected_pex, "-c", "import pythonnet"])

--- a/python/tests/test_issue_135.py
+++ b/python/tests/test_issue_135.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Pex project contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+
+import os.path
+import subprocess
+
+import pytest
+from testing import IS_WINDOWS, IS_X86_64, pexrc_inject
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    # Ruff doesn't understand Python 2 and thus the type comment usages.
+    from typing import Any  # noqa: F401
+
+
+@pytest.mark.skipif(
+    not (IS_WINDOWS and IS_X86_64),
+    reason=(
+        "The test requires the pythonnet dependency under test to be consumed as a win-amd64 wheel."
+    ),
+)
+def test_issue_135(tmpdir):
+    # type: (Any) -> None
+
+    pex = os.path.join(tmpdir, "pex")
+    subprocess.check_call(
+        args=["pex", "--platform", "win-amd64-cp-314-cp314", "pythonnet==3.1.0", "-o", pex]
+    )
+    injected_pex = pexrc_inject(pex)
+    subprocess.check_call(args=[injected_pex, "-c", "import pythonnet"])

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -158,16 +158,24 @@ impl<'a> RequiredTargets<'a> {
             targets_by_project_name
                 .entry(wheel.project_name)
                 .or_insert_with(HashSet::new)
-                .extend(
-                    wheel
+                .extend({
+                    let compatible = wheel
                         .tags
                         .iter()
-                        .map(|tag| {
+                        .filter_map(|tag| {
                             SimplifiedTarget::for_platform_tag(tag.platform)
                                 .map(|targets| targets.map(|targets| (wheel.file_name, targets)))
+                                .ok()
                         })
-                        .collect::<anyhow::Result<Vec<_>>>()?,
-                );
+                        .collect::<Vec<_>>();
+                    if compatible.is_empty() {
+                        bail!(
+                            "There are no pexrc binaries available that support {wheel}.",
+                            wheel = wheel.file_name
+                        )
+                    }
+                    compatible
+                });
         }
         let mut required_targets = IndexSet::new();
         for required in targets_by_project_name.values() {


### PR DESCRIPTION
Previously compressed tag sets were not handled correctly leading to
spurious errors auto-detecting the correct target.

Fixes #135