### PR TITLE
Beef up documentation on tag test.

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -507,9 +507,13 @@ mod tests {
                     "pip",
                     "install",
                     // N.B.: This commit includes two unreleased fixes:
-                    // + Fixed linux / manylinux tag ordering.
-                    // + Fixed fat32 -> fat3 for macOS abi tags.
-                    // TODO: Revert to just "packaging" (latest) once these fixes are released.
+                    // + Fixed linux / manylinux tag ordering:
+                    //   * https://github.com/pypa/packaging/issues/160
+                    //   * https://github.com/pypa/packaging/commit/68cdb4d400823b401c1a40969964f509636a8094
+                    // + Fixed fat32 -> fat3 for macOS abi tags:
+                    //   * https://github.com/pypa/packaging/pull/1199
+                    // TODO: Revert to just "packaging" (latest) once these fixes are released in
+                    //  packaging 26.3.
                     "packaging @ git+https://github.com/pypa/packaging@45d15309ac4a2411196e800378f2"
                 ])
                 .spawn()


### PR DESCRIPTION
Link https://github.com/pypa/packaging/issues/160 for the
`linux` / `m{any,usl}linux` flip-flop.

This is the result of root-causing
https://github.com/pex-tool/pex/issues/3214