### PR TITLE
Fix handling of macOS Python Framework builds.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.16.4
+
+This release fixes handling of macOS Python Framework builds.
+
 ## 0.16.3
 
 This release fixes Python release candidate handling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "pexrc"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "pexrc"
-version = "0.16.3"
+version = "0.16.4"
 edition = { workspace = true }
 publish = false
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -168,7 +168,7 @@ impl CacheDir {
 
     fn version(&self) -> &'static str {
         match self {
-            CacheDir::Interpreter => "2",
+            CacheDir::Interpreter => "3",
             CacheDir::PythonProxy => "0",
             CacheDir::Venv => "1",
         }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -39,6 +39,7 @@ pub struct InterpreterDetails {
     pub cpython_abi_info: Option<CPythonAbiInfo>,
     pub paths: BTreeMap<String, PathBuf>,
     pub has_ensurepip: bool,
+    pub is_framework: bool,
 }
 
 impl InterpreterDetails {

--- a/crates/scripts/src/interpreter.py
+++ b/crates/scripts/src/interpreter.py
@@ -77,6 +77,8 @@ def identify(sys_config_vars):
     except ImportError:
         has_ensurepip = False
 
+    is_framework = bool(sys_config_vars.get("PYTHONFRAMEWORK"))
+
     pypy_version = cast(
         "Optional[Tuple[int, int, int]]",
         tuple(getattr(sys, "pypy_version_info", ())[:3]) or None,
@@ -101,6 +103,7 @@ def identify(sys_config_vars):
         "cpython_abi_info": abi_info,
         "paths": sysconfig.get_paths(),
         "has_ensurepip": has_ensurepip,
+        "is_framework": is_framework,
     }
 
 

--- a/crates/venv/src/virtualenv.rs
+++ b/crates/venv/src/virtualenv.rs
@@ -154,6 +154,20 @@ impl<'a> Virtualenv<'a> {
             )?
         };
 
+        // N.B.: Self::host_interpreter used above to pre-calculate venv interpreter details fails
+        // for macOS Python framework builds. As such, for exactly those builds, we run the
+        // interpreter identification script in the context of the venv Python to get accurate
+        // details.
+        //
+        // See: https://github.com/pex-tool/pex.rc/issues/134
+        #[cfg(target_os = "macos")]
+        let venv_interpreter = if venv_interpreter.details.is_framework {
+            let identify_interpreter = IdentifyInterpreter::read(scripts)?;
+            Interpreter::load(&venv_interpreter.details.path, &identify_interpreter)?
+        } else {
+            venv_interpreter
+        };
+
         Ok(Self {
             interpreter: venv_interpreter,
             bin_dir_relpath: SCRIPTS_DIR,


### PR DESCRIPTION
Previously, when a Python Framework build was used to populate a venv,
its `sysconfig` paths (bin dir, etc.) were calculated incorrectly,
leading to incorrect wheel installs.

Fixes #134